### PR TITLE
Massive refactor to utilize a database

### DIFF
--- a/src/commands/commandParser.js
+++ b/src/commands/commandParser.js
@@ -1,44 +1,60 @@
 const HELPERS = require('../helpers/helpers');
 const LOGGER = require('../helpers/logger');
-
+var persistenceService = require('../services/persistenceService');
 var guildService = require('../services/guildService.js');
 
+/* DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
 var CONFIG;
 function injectConfig(_cfg) {
     CONFIG = _cfg;
 }
+*/
 
-async function parseCommand(message) {
+async function parseCommand(message,configured) {
+	// Responds to .configure only when not yet configured. Once configured, .config is needed.
+	if (configured) {
+		var cfg = CONFIG.servers[message.guild.id];				
+		var countedStrings = await persistenceService.getAllSips(message.guild.id);
+		countedStrings = countedStrings.structure; // set to only the columns
+		countedStrings.splice(0,2); // remove the first column 'userId & lastSip'
     //Handle some events with auth
-    if (CONFIG.countedStrings.includes(message.content.toLowerCase())) {
+    if (countedStrings.includes(message.content.toLowerCase())) {
         //Handle command we don't need access for 
         command = require('./sipCommand');
-        command.injectConfig(CONFIG)
+        //command.injectConfig(cfg) DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
         return command.handle(message);
     }
     else if (message.content == ".sipstats") {
         command = require('./sipStatsCommand');
-        command.injectConfig(CONFIG)
+        //command.injectConfig(cfg) DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
         return command.handle(message);
     }   
-    // It will do nothing when the message doesnt start with the prefix
-    if(!message.content.startsWith(CONFIG.commandPrefix)) return;   
+    // It will do nothing when the message doesn't start with the prefix
+    if(!message.content.startsWith(cfg.commandPrefix)) return;
     //Also try and catch mistakes. Especially watch p as its used by the rhythm bot
-    if (message.content.startsWith(CONFIG.commandPrefix + CONFIG.commandPrefix) ||
-        message.content.startsWith(CONFIG.commandPrefix + "p") ||
-        message.content.startsWith(CONFIG.commandPrefix + " ") 
+    if (message.content.startsWith(cfg.commandPrefix + cfg.commandPrefix) ||
+        message.content.startsWith(cfg.commandPrefix + "p") ||
+        message.content.startsWith(cfg.commandPrefix + " ") 
     ) return;   
     authorId = message.author.id;
-    refreshedAuthorObj = await guildService.getMemberForceLoad(authorId);   
+    var refreshedAuthorObj = await guildService.getMemberForceLoad(authorId);   
     //Process our message
-    commandStr = HELPERS.trimCommand(message);  
-    //Verify the user has the right to user the bot
-    if (!HELPERS.doesUserHaveRole(refreshedAuthorObj, CONFIG.botMasterRole)) {
-        LOGGER.log("UNAUTHORIZED USAGE ATTEMPT: " + message.author.username + " Tried to use me with this command: " + commandStr);
-        if (CONFIG.warnAuthorizedUsage)
-            message.channel.send("You don't have the rights to use me you filthy swine.");
+    var commandStr = HELPERS.trimCommand(message);  
+    //Verify the user has the right to use the bot
+    let hasRightToUse = false;
+    if (
+        refreshedAuthorObj._roles.includes(cfg.botUserRole) ||
+        message.member.permissions.has(1 << 3) ||
+        refreshedAuthorObj._roles.includes(cfg.botMasterRole)
+    ) {
+        hasRightToUse = true;
+    }
+    if (!hasRightToUse) {
+        LOGGER.log("UNAUTHORIZED USAGE ATTEMPT: <@" + authorId + "> (" + message.author.tag + ") (" + authorId + ") Tried to use me with this command: " + commandStr);
+        if (cfg.warnAuthorizedUsage)
+            message.channel.send("You don't have the rights to use me you filthy swine!");
         return;
-    }   
+    }
     var command;
     switch (commandStr) {
         case "help":
@@ -55,19 +71,46 @@ async function parseCommand(message) {
             break;  
         case "tankstats":
             command = require('./tankStatsCommand');
-            break;  
-        case "synctank":
+            break; 
+				case "config":
+				    command = require('./configCommand');
+						break;
+        /*case "synctank":
             command = require('./syncTankCommand');
-            break;  
+            break;  DEPRECATED AND REMOVED; uses DB now instead of DRP */
         default:
-            if (CONFIG.warnAuthorizedUsage)
-                return message.channel.send("I don't know that command. Want me to build it? Do it yourself you lazy throbber");
-
+            if (cfg.warnAuthorizedUsage) {
+              return message.channel.send("I don't know that command. Want me to build it? Do it yourself you lazy throbber");
+						}
             return;
     }   
-    command.injectConfig(CONFIG)
+    //command.injectConfig(CONFIG) DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
     return command.handle(message); 
+	} else {
+		var prefix = ".";
+		// Is there any server config set?
+		if (CONFIG.servers[message.guild.id] !== undefined) { // avoids undefined property read error.
+			if (
+				(CONFIG.servers[message.guild.id].commandPrefix !== null) && 
+				(typeof CONFIG.servers[message.guild.id].commandPrefix !== "undefined")
+			) {
+				prefix = CONFIG.servers[message.guild.id].commandPrefix;
+			}
+		}
+		// Was the command `.configure`?
+		if (message.content.startsWith(prefix + "configure")) {
+			// THIS IS THE ONLY COMMAND WE WILL RESPOND TO WHEN ITS FROM AN UNCONFIGURED SERVER
+			// First make sure the configuring user has ADMINISTRATOR here.
+			if (!message.member.permissions.has(1 << 3)) {
+				return; // Don't even acknowledge the message.
+			}
+			// call the default configure function
+			command = require('./configCommand');
+			return command.configure(message, prefix);
+		}
+		return; // Ignore the message, wasn't for the bot.
+	}
 }
 
-exports.injectConfig = injectConfig;
+//exports.injectConfig = injectConfig;
 exports.parseCommand = parseCommand;

--- a/src/commands/commandParser.js
+++ b/src/commands/commandParser.js
@@ -34,7 +34,8 @@ async function parseCommand(message,configured) {
     //Also try and catch mistakes. Especially watch p as its used by the rhythm bot
     if (message.content.startsWith(cfg.commandPrefix + cfg.commandPrefix) ||
         message.content.startsWith(cfg.commandPrefix + "p") ||
-        message.content.startsWith(cfg.commandPrefix + " ") 
+        message.content.startsWith(cfg.commandPrefix + " ") ||
+        message.content === (cfg.commandPrefix + "")
     ) return;   
     authorId = message.author.id;
     var refreshedAuthorObj = await guildService.getMemberForceLoad(authorId);   

--- a/src/commands/configCommand.js
+++ b/src/commands/configCommand.js
@@ -1,0 +1,794 @@
+const HELPERS = require('../helpers/helpers');
+var dbManager = require('../managers/dbConnectionManager.js');
+var persistenceService = require('../services/persistenceService');
+
+/* DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
+var CONFIG;
+function injectConfig(_cfg) {
+    CONFIG = _cfg;
+}
+*/
+
+async function configure(m,p) {
+	// THIS COMMAND SHOULD ONLY RUN ON AN UNCONFIGURED SERVER AND ONLY BY AN ADMINISTRATOR.
+	// ACCESS TO THIS COMMAND IS OTHERWISE IMPOSSIBLE. DO NOT MAKE IT AVAILABLE.
+	
+	// DEFAULT SERVER CONFIGURATIONS
+	var cfg = {
+		serverID: m.guild.id,
+		commandPrefix: ".",
+		botMasterRole: null,
+		botUserRole: null,
+		drunktankRole: null,
+		tankChannel: m.channel.id,
+		logChannel: m.channel.id,
+		invitesChannel: m.channel.id,
+		namesChannel: m.channel.id,
+		modlogChannel: m.channel.id,
+		bypassGMU: m.client.user.id,
+		rolesToIgnore: null,
+		rolesICannotTank: null,
+		tankUOM: "hours",
+		tankDuration: 12,
+		writeMessageToDrunkTank: false,
+		warnAuthorizedUsage: false,
+		startServer: false
+	};
+	
+	// check if Server Booster role is set
+	if (!!m.guild.roles.premiumSubscriberRole) {
+		cfg.rolesToIgnore = m.guild.roles.premiumSubscriberRole.id;
+	}
+	
+	// FINAL CHECK TO ENSURE THAT THE SERVER DOESN'T YET EXIST IN THE DB WHEN CALLING THE EMPTY COMMAND `.CONFIGURE`.
+	if ((m.content === p + "configure") && (!CONFIG.servers[m.guild.id])) {
+		// Create the server config
+		var queryConfig = {
+			insert: "config",
+			columns: Object.keys(cfg),
+			valueHolders: [],
+			values: Object.values(cfg)
+		};
+		Object.keys(cfg).forEach((a)=>{
+			queryConfig.valueHolders.push("?");
+		});
+		queryConfig.valueHolders.join(",");
+		queryConfig.valueHolders = "(" + queryConfig.valueHolders + ")";
+		
+		var queryTankees = {
+			create: m.guild.id + "_tankees",
+			columns: [
+				"`time_tanked` BIGINT(14) UNSIGNED NOT NULL PRIMARY KEY",
+				"`user_tanked` VARCHAR(20) NOT NULL",
+				"`tanked_by` VARCHAR(20) NOT NULL",
+				"`tank_reason` VARCHAR(1990) NULL",
+				"`time_to_untank` BIGINT(14) UNSIGNED NOT NULL",
+				"`roles_to_give_back` VARCHAR(2099) NOT NULL",
+				"`time_untanked` BIGINT(14) UNSIGNED NULL",
+				"`untanked_by` VARCHAR(20) NULL",
+				"`untanked_reason` VARCHAR(1990) NULL"
+			]
+		};
+		
+		var queryBuffers = {
+			create: m.guild.id + "_buffers",
+			columns: [
+				"`id` INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY",
+				"`time` BIGINT(14) UNSIGNED NOT NULL",
+				"`channel` VARCHAR(7) NOT NULL",
+				"`msg` VARCHAR(16384) NOT NULL"
+			]
+		};
+		
+		var querySips = {
+			create: m.guild.id + "_sips",
+			columns: [
+			  "`userId` VARCHAR(20) NOT NULL PRIMARY KEY",
+				"`lastSip` BIGINT(14) UNSIGNED NOT NULL",
+				"`sip` INT(10) UNSIGNED NOT NULL"
+			]
+		};
+		
+		var queryInvites = {
+			create: m.guild.id + "_invites",
+			columns: [
+				"`code` VARCHAR(25) NOT NULL PRIMARY KEY",
+				"`inviter` VARCHAR(20) NOT NULL",
+				"`uses` INT UNSIGNED NOT NULL",
+				"`dummies` INT UNSIGNED NOT NULL",
+				"`deleted` TINYINT(1) UNSIGNED NOT NULL"
+			]
+		};
+		
+		var queryInviteUses = {
+			create: m.guild.id + "_invite_uses",
+			columns: [
+			  "`joined` BIGINT(14) UNSIGNED NOT NULL PRIMARY KEY",
+				"`code` VARCHAR(25) NOT NULL",
+			  "`user` VARCHAR(20) NOT NULL"
+			]
+		};
+		
+		await dbManager.Query(queryConfig);
+		await dbManager.Query(queryTankees);
+		await dbManager.Query(queryBuffers);
+		await dbManager.Query(querySips);
+		await dbManager.Query(queryInvites);
+		await dbManager.Query(queryInviteUses);
+		
+		await reloadConfig(m.guild.id);
+		var msg = "";
+		if (CONFIG.servers[m.guild.id].serverID = m.guild.id) {
+			msg = "Server initial configuration successful." +
+			  "\r\nYour current Configuration: " + 
+		    "\r\n```" +
+				'\r\ncommandPrefix: .' +
+				'\r\nbotMasterRole: **NOT SET**' +
+				'\r\nbotUserRole: **NOT SET**' +
+				'\r\ndrunktankRole: **NOT SET**' +
+				'\r\ntankChannel: ' + CONFIG.servers[m.guild.id].tankChannel +
+				'\r\nlogChannel: ' + CONFIG.servers[m.guild.id].logChannel +
+				'\r\ninvitesChannel: ' + CONFIG.servers[m.guild.id].invitesChannel +
+				'\r\nnamesChannel: ' + CONFIG.servers[m.guild.id].namesChannel +
+				'\r\nmodlogChannel: ' + CONFIG.servers[m.guild.id].modlogChannel +
+				'\r\nbypassGMU: ' + CONFIG.servers[m.guild.id].bypassGMU +
+				'\r\nrolesToIgnore: ' + (CONFIG.servers[m.guild.id].rolesToIgnore === null ? '**NOT SET**' : CONFIG.servers[m.guild.id].rolesToIgnore) +
+				'\r\nrolesICannotTank: **NOT SET**' +
+				'\r\ntankUOM: hours' +
+				'\r\ntankDuration: 12' +
+				'\r\nwriteMessageToDrunkTank: no' +
+				'\r\nwarnAuthorizedUsage: no' +
+				"\r\n```" +
+				"\r\nYou can set individual items using `.configure <setting> set|add|remove <value>`" +
+				"\r\n(add|remove only for bypassGMU, rolesToIgnore, rolesICannotTank)\r\n" +
+				
+				"\r\nYou **must** set a botMasterRole, botUserRole, and drunktankRole before you can start the bot fully. The Channel configs are *recommended* to be different channels.\r\n" +
+		 
+				"\r\nUse raw IDs for all roles, users, and channels." +
+				"\r\nUse 0 (false) or 1 (true) for any true/false/yes/no values." +
+				"\r\nType `.configure <setting> help` for additional information." +
+				"\r\nExecute the command `.configure start` to confirm configuration and begin the bot.";
+		} else {
+			msg = "Server initial configuration failed. If this continues, contact the Bot Developer.";
+		}
+		return m.channel.send(msg);
+	} else {
+		// Listening for next configurations without starting server
+		return resolveCommand(m);
+	}
+}
+
+async function resolveCommand(message) {
+	// .configure and .config will both redirect here. We allow .configure to change settings whilst the server has not started, but it will change over to .config once started.
+	// .config cannot alter startServer.
+	var command = HELPERS.trimCommand(message);
+	var tokens = HELPERS.trimMsg(message);
+	tokens = HELPERS.tokenize(tokens.substr(1,tokens.length -1));
+	var setting = tokens[0];
+	tokens.slice(1);
+	var msg = "";
+	if ((setting === "start") && (command === "configure")) {
+		// Bot requires that these are configured first
+		if (CONFIG.servers[message.guild.id].botMasterRole === null) {
+			return message.channel.send("You must configure the botMasterRole.");
+		}
+		if (CONFIG.servers[message.guild.id].botUserRole === null) {
+			return message.channel.send("You must configure the botUserRole.");
+		}
+		if (CONFIG.servers[message.guild.id].drunktankRole === null) {
+			return message.channel.send("You must configure the drunktankRole.");
+		}
+		var queryConfig = {
+			update: "config",
+			sets: "startServer = ?",
+			where: "serverID = ?",
+			values: [true, message.guild.id]
+		};
+		
+		await dbManager.Query(queryConfig);
+		await reloadConfig(message.guild.id);
+		if (CONFIG.servers[message.guild.id].startServer) {
+			msg = "Server Configuration successfully loaded and started.";
+		} else {
+			msg = "Server initial configuration failed. If this continues, contact the Bot Developer.";
+		}
+		return message.channel.send(msg);
+		
+	}
+	var result = -1;
+	switch (setting) {
+		case "commandPrefix":
+			switch (tokens[1]) {
+				case "set":
+					if (tokens[2].length !== 1) {
+						msg += "Command Prefix must be a single character.";
+					} else {
+						result = await updateConfig(message.guild.id, setting, tokens[2].toString());
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + CONFIG.servers[message.guild.id][setting] +
+					"\r\nInfo: Changes the command prefix for the bot.";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " set <char>`";
+					break;
+			}
+			break;
+		case "botMasterRole":
+		  switch (tokens[1]) {
+				case "set":
+				  let id = await message.guild.roles.fetch(tokens[2]);
+					if (id === null) {
+						msg += "That role doesn't exist.";
+					} else {
+						result = await updateConfig(message.guild.id, setting, tokens[2]);
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + CONFIG.servers[message.guild.id][setting] +
+					"\r\nInfo: Sets the role needed to configure the bot. Accepts a role ID. Anyone with Administrator Permission is also a Bot Master.";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " set <roleID>`";
+					break;
+			}
+			break;
+		case "botUserRole":
+			switch (tokens[1]) {
+				case "set":
+					let id = await message.guild.roles.fetch(tokens[2]);
+					if (id === null) {
+						msg += "That role doesn't exist.";
+					} else {
+						result = await updateConfig(message.guild.id, setting, tokens[2]);
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + CONFIG.servers[message.guild.id][setting] +
+					"\r\nInfo: Sets the role needed to run bot commands (except configuration). Accepts a role ID. Anyone with Administrator Permission is also a Bot User.";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " set <roleID>`";
+					break;
+			}
+			break;
+		case "drunktankRole":
+			switch (tokens[1]) {
+				case "set":
+					let id = await message.guild.roles.fetch(tokens[2]);
+					if (id === null) {
+						msg += "That role doesn't exist.";
+					} else {
+						result = await updateConfig(message.guild.id, setting, tokens[2]);
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + CONFIG.servers[message.guild.id][setting] +
+					"\r\nInfo: Sets the DrunkTank role that the bot will give to users when they are tanked. Accepts a role ID.";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " set <roleID>`";
+					break;
+			}
+			break;
+		case "tankChannel":
+			switch (tokens[1]) {
+				case "set":
+					let id = await message.guild.channels.resolve(tokens[2]);
+					if (id === null) {
+						msg += "That channel doesn't exist.";
+					} else {
+						result = await updateConfig(message.guild.id, setting, tokens[2]);
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + CONFIG.servers[message.guild.id][setting] +
+					"\r\nInfo: Sets the channel where tanked users will see messages. Accepts a channel ID.";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " set <channelID>`";
+					break;
+			}
+			break;
+		case "logChannel":
+			switch (tokens[1]) {
+				case "set":
+					let id = await message.guild.channels.resolve(tokens[2]);
+					if (id === null) {
+						msg += "That channel doesn't exist.";
+					} else {
+						result = await updateConfig(message.guild.id, setting, tokens[2]);
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + CONFIG.servers[message.guild.id][setting] +
+					"\r\nInfo: Sets the channel where tank actions will be logged. Accepts a channel ID.";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " set <channelID>`";
+					break;
+			}
+			break;
+		case "invitesChannel":
+			switch (tokens[1]) {
+				case "set":
+					let id = await message.guild.channels.resolve(tokens[2]);
+					if (id === null) {
+						msg += "That channel doesn't exist.";
+					} else {
+						result = await updateConfig(message.guild.id, setting, tokens[2]);
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + CONFIG.servers[message.guild.id][setting] +
+					"\r\nInfo: Sets the channel where invites, joins, and, leaves will be logged. Accepts a channel ID.";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " set <channelID>`";
+					break;
+			}
+			break;
+		case "namesChannel":
+			switch (tokens[1]) {
+				case "set":
+					let id = await message.guild.channels.resolve(tokens[2]);
+					if (id === null) {
+						msg += "That channel doesn't exist.";
+					} else {
+						result = await updateConfig(message.guild.id, setting, tokens[2]);
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + CONFIG.servers[message.guild.id][setting] +
+					"\r\nInfo: Sets the channel where user name changes will be logged. Accepts a channel ID.";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " set <channelID>`";
+					break;
+			}
+			break;
+		case "modlogChannel":
+			switch (tokens[1]) {
+				case "set":
+					let id = await message.guild.channels.resolve(tokens[2]);
+					if (id === null) {
+						msg += "That channel doesn't exist.";
+					} else {
+						result = await updateConfig(message.guild.id, setting, tokens[2]);
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + CONFIG.servers[message.guild.id][setting] +
+					"\r\nInfo: Sets the channel where mod-level logs will be sent. Accepts a channel ID. Set this to a channel that is not accessible by botUserRole.";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " set <channelID>`";
+					break;
+			}
+			break;
+		case "bypassGMU":
+			switch (tokens[1]) {
+				case "add":
+					let rid = await message.guild.roles.fetch(tokens[2]);
+					let uid = await message.guild.members.fetch(tokens[2]).catch((e)=>{return null;});
+					if ((rid === null) && (uid === null)) {
+						msg += "That role/user doesn't exist.";
+					} else {
+						let val = CONFIG.servers[message.guild.id][setting];
+						if (val === null) {
+							val = [];
+						}
+						if (!val.includes(tokens[2].toString())) {
+							val.push(tokens[2].toString());
+							result = await updateConfig(message.guild.id, setting, val);
+						} else {
+							msg += "That role/user is already added.";
+						}
+					}
+				  break;
+				case "remove":
+					let val = CONFIG.servers[message.guild.id][setting];
+					if (val === null) {
+						val = [];
+					}
+					if (val.includes(tokens[2].toString())) {
+						val.splice(val.indexOf(tokens[2].toString(),1));
+						result = await updateConfig(message.guild.id, setting, val);
+					} else {
+						msg += "That role/user isn't in the list.";
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + (CONFIG.servers[message.guild.id][setting] !== null ? CONFIG.servers[message.guild.id][setting].join(", ") : "***NOT SET***") +
+					"\r\nInfo: Add/Remove a role or user to a group that will be ignored by this bot. Accepts a role or user ID. This setting is preconfigured to include this bot.";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " add|remove <roleID | userID>`";
+					break;
+			}
+			break;
+		case "rolesToIgnore":
+			switch (tokens[1]) {
+				case "add":
+					let id = await message.guild.roles.fetch(tokens[2]);
+					if (id === null) {
+						msg += "That role doesn't exist.";
+					} else {
+						let val = CONFIG.servers[message.guild.id][setting];
+						if (val === null) {
+							val = [];
+						} 
+						if (!val.includes(tokens[2].toString())) {
+							val.push(tokens[2].toString());
+							result = await updateConfig(message.guild.id, setting, val);
+						} else {
+							msg += "That role is already added.";
+						}
+					}
+					break;
+				case "remove":
+					let val = CONFIG.servers[message.guild.id][setting];
+					if (val === null) {
+						val = [];
+					}
+					if (val.includes(tokens[2].toString())) {
+						val.splice(val.indexOf(tokens[2].toString(),1));
+						result = await updateConfig(message.guild.id, setting, val);
+					} else {
+						msg += "That role isn't in the list.";
+					}
+					break;
+				case "help":
+					msg += setting + ": " + (CONFIG.servers[message.guild.id][setting] !== null ? CONFIG.servers[message.guild.id][setting].join(", ") : "***NOT SET***") +
+					"\r\nInfo: Add/Remove roles that the bot will not grant or remove from a user. Accepts a role ID.";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " add|remove <roleID>`";
+					break;
+			}
+			break;
+		case "rolesICannotTank":
+			switch (tokens[1]) {
+				case "add":
+					let id = await message.guild.roles.fetch(tokens[2]);
+					if (id === null) {
+						msg += "That role doesn't exist.";
+					} else {
+						let val = CONFIG.servers[message.guild.id][setting];
+						if (val === null) {
+							val = [];
+						}
+						if (!val.includes(tokens[2].toString())) {
+							val.push(tokens[2].toString());
+							result = await updateConfig(message.guild.id, setting, val);
+						} else {
+							msg += "That role is already added.";
+						}
+					}
+					break;
+				case "remove":
+					let val = CONFIG.servers[message.guild.id][setting];
+					if (val === null) {
+						val = [];
+					}
+					if (val.includes(tokens[2].toString())) {
+						val.splice(val.indexOf(tokens[2].toString(),1));
+						result = await updateConfig(message.guild.id, setting, val);
+					} else {
+						msg += "That role isn't in the list.";
+					}
+					break;
+				case "help":
+					msg += setting + ": " + (CONFIG.servers[message.guild.id][setting] !== null ? CONFIG.servers[message.guild.id][setting].join(", ") : "***NOT SET***") +
+					"\r\nInfo: Add/Remove a role that the bot will be unable to tank. Accepts a role ID. Bot Users and Bot Masters are already untankable, please don't add them (I don't want to have to check for you).";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " add|remove <roleID>`";
+					break;
+			}
+			break;
+		case "tankUOM":
+			switch (tokens[1]) {
+				case "set":
+					if (!(
+					  (tokens[2] === "minutes") ||
+						(tokens[2] === "hours") ||
+						(tokens[2] === "days")
+					)){
+						msg += "Unit Of Measure must be minutes, hours, or days. Be sure to check your spelling.";
+					} else {
+						if (tokens[2] === CONFIG.servers[message.guild.id][setting]) {
+							msg += "tankUOM is already set to " + tokens[2] + ".";
+						} else {
+							result = await updateConfig(message.guild.id, setting, tokens[2]);
+						}
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + CONFIG.servers[message.guild.id][setting] +
+					"\r\nInfo: Sets the default Unit Of Measure (UOM) when tanking a user without a specified time. Accepts minutes, hours, or days (not abbreviated).";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " set <minutes|hours|days>`";
+					break;
+			}
+			break;
+		case "tankDuration":
+			switch (tokens[1]) {
+				case "set":
+				  if (isNaN(parseInt(tokens[2],10))) {
+						msg += "Duration needs to be a positive integer.";
+					} else {
+						if (parseInt(tokens[2],10) < 1){
+							msg += "Duration cannot be less than 1.";
+						} else {
+							if (parseInt(tokens[2],10) == CONFIG.servers[message.guild.id][setting]) {
+								msg += "Duration is already set to " + tokens[2] + ".";
+							} else {
+								result = await updateConfig(message.guild.id, setting, parseInt(tokens[2],10));
+							}
+						}
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + CONFIG.servers[message.guild.id][setting] +
+					"\r\nInfo: Sets the default Duration when tanking a user without a specified time. Accepts a number (decimals will be dropped, not rounded)";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " set <value>`";
+					break;
+			}
+			break;
+		case "writeMessageToDrunkTank":
+			switch (tokens[1]) {
+				case "set":
+					if (isNaN(parseInt(tokens[2],10))) {
+						msg += "Value needs to be numerical, preferably 0 or 1.";
+					} else {
+						if (!!parseInt(tokens[2],10) === CONFIG.servers[message.guild.id][setting]) {
+							msg += "It's already set to " + !!parseInt(tokens[2],10) + ".";
+						} else {
+							result = await updateConfig(message.guild.id, setting, !!parseInt(tokens[2],10));
+						}
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + Number(CONFIG.servers[message.guild.id][setting]) +
+					"\r\nInfo: If set to 1, will write an additional message in the drunktank when a user gets tanked. Accepts a numerical input, preferably 0 or 1 (will be converted anyway).";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " set <value>`";
+					break;
+			}
+			break;
+		case "warnAuthorizedUsage":
+			switch (tokens[1]) {
+				case "set":
+					if (isNaN(parseInt(tokens[2],10))) {
+						msg += "Value needs to be numerical, preferably 0 or 1.";
+					} else {
+						if (!!parseInt(tokens[2],10) === CONFIG.servers[message.guild.id][setting]) {
+							msg += "It's already set to " + !!parseInt(tokens[2],10) + ".";
+						} else {
+							result = await updateConfig(message.guild.id, setting, !!parseInt(tokens[2],10));
+						}
+					}
+				  break;
+				case "help":
+					msg += setting + ": " + Number(CONFIG.servers[message.guild.id][setting]) +
+					"\r\nInfo: If set to 1, will respond to an unauthorized user with an insult, and refuse to oblige the user's command attempt. Accepts a numerical input, preferably 0 or 1 (will be converted anyway). *Logged actions are currently only done in the hosted bot's console in order to keep logs from getting overfilled.*";
+				  break;
+				default:
+				  msg += "Invalid argument. Correct Usage: `" + 
+					CONFIG.servers[message.guild.id].commandPrefix + command + " " + setting + " set <value>`";
+					break;
+			}
+			break;
+		case "help":
+		  // array helpers
+			let arrs = {
+				bypassGMU: CONFIG.servers[message.guild.id].bypassGMU,
+				rolesToIgnore: CONFIG.servers[message.guild.id].rolesToIgnore,
+				rolesICannotTank: CONFIG.servers[message.guild.id].rolesICannotTank
+			};
+			
+			Object.entries(arrs).forEach((i,o) => {
+				if (o === null) {
+					arrs[i] = "null";
+				}
+				if (Array.isArray(o)) {
+					arrs[i] = o.join(", ");
+				}
+			});
+		  msg += "Current Settings:" +
+						"\r\n```" +
+						'\r\ncommandPrefix: ' + CONFIG.servers[message.guild.id].commandPrefix +
+						'\r\nbotMasterRole: ' + CONFIG.servers[message.guild.id].botMasterRole +
+						'\r\nbotUserRole: ' + CONFIG.servers[message.guild.id].botUserRole +
+						'\r\ndrunktankRole: ' + CONFIG.servers[message.guild.id].drunktankRole +
+						'\r\ntankChannel: ' + CONFIG.servers[message.guild.id].tankChannel +
+						'\r\nlogChannel: ' + CONFIG.servers[message.guild.id].logChannel +
+						'\r\ninvitesChannel: ' + CONFIG.servers[message.guild.id].invitesChannel +
+						'\r\nnamesChannel: ' + CONFIG.servers[message.guild.id].namesChannel +
+						'\r\nmodlogChannel: ' + CONFIG.servers[message.guild.id].modlogChannel +
+						'\r\nbypassGMU: ' + arrs.bypassGMU +
+						'\r\nrolesToIgnore: ' + arrs.rolesToIgnore +
+						'\r\nrolesICannotTank: ' + arrs.rolesICannotTank +
+						'\r\ntankUOM: ' + CONFIG.servers[message.guild.id].tankUOM +
+						'\r\ntankDuration: ' + CONFIG.servers[message.guild.id].tankDuration +
+						'\r\nwriteMessageToDrunkTank: ' + CONFIG.servers[message.guild.id].writeMessageToDrunkTank +
+						'\r\nwarnAuthorizedUsage: ' + CONFIG.servers[message.guild.id].warnAuthorizedUsage +
+						"\r\n```" +
+						'\r\n' + (CONFIG.servers[message.guild.id].startServer ? "*SERVER IS RUNNING*" : "**SERVER IS __NOT__ RUNNING**") +
+						 "\r\nConfigurable Options:" +
+						 "\r\n```" +
+						 "\r\ncommandPrefix, botMasterRole, botUserRole, drunktankRole, tankChannel, logChannel, invitesChannel, namesChannel, modlogChannel, bypassGMU, rolesToIgnore, rolesICannotTank, tankUOM, tankDuration, writeMessageToDrunkTank, warnAuthorizedUsage, startServer" +
+						 "\r\n```" +
+						 "\r\nOther options:" +
+						 "\r\n```" +
+						 "\r\nhelp, getinvites, forceReload" +
+						 "\r\n```" +
+						 "\r\nBot Version: " + HELPERS.BOT_VERSION() + " - written by stevie_pricks#1903 & Sindrah#9620";
+			break;
+		case "forceReload":
+		  let x = JSON.stringify(CONFIG.servers[message.guild.id]);
+			let y = await reloadConfig(message.guild.id);
+			let z = JSON.stringify(CONFIG.servers[message.guild.id]);
+			if ((x === z) && (y)) {
+				msg += "Configuration successfully reloaded. No changes.";
+			} else if ((x !== z) && (y)) {
+				msg += "Configuration successfully reloaded with new settings.";
+			} else {
+				msg += "Configuration failed to reload.";
+			}
+		  break;
+		case "getinvites":
+		  inviteService = require("../services/inviteService");
+			let invs = await inviteService.storeInvites(message.guild);
+			if (!invs.err) {
+				msg += invs.saved + " Invite" + (invs.saved === 1 ? " has " : "s have ") + "been stored in the database.";
+			} else {
+				msg += "An error was encountered during the storage of invites. " + invs.saved + " were saved and " + invs.lost + " were not saved.";
+			}
+			break;
+		default:
+		  setting = (setting === "" ? " " : setting);
+			msg += "`" + setting + "` is not valid. Try using `help` to see what commands this configurator can work with.";
+			break;
+	}
+	if (result > 0) {
+		let act = "";
+		if (tokens[1] === "set") {act = "set";}
+		if (tokens[1] === "add") {act = "added";}
+		if (tokens[1] === "remove") {act = "removed";}
+		msg += setting + " successfully " + act + " `" + tokens[2] + "`.";
+	} else if (result === 0){
+		msg += setting + " failed to " + tokens[1] + " `" + tokens[2] + "`.";
+	}
+	return message.channel.send(msg);
+}
+
+async function updateConfig(guild, setting, value) {
+	cVal = {
+		botMasterRole: "string",
+		botUserRole: "string",
+		drunktankRole: "string",
+		tankChannel: "string",
+		logChannel: "string",
+		invitesChannel: "string",
+		namesChannel: "string",
+		modlogChannel: "string",
+		bypassGMU: "array",
+		rolesToIgnore: "array",
+		rolesICannotTank: "array",
+		tankUOM: "string",
+		tankDuration: "integer",
+		writeMessageToDrunkTank: "boolean",
+		warnAuthorizedUsage: "boolean"
+	};
+	
+	//convert the value to the intended type for the DB
+	switch(cVal[setting]) {
+		case "integer":
+			value = parseInt(value,10);
+			break;
+		case "string":
+		  value = value.toString();
+			break;
+		case "array":
+			value = value.length < 1 ? null : value.join(",");
+		  break;
+		case "boolean":
+			value = !!value;
+			break;
+	}
+	
+	query = {
+		update: 'config',
+		sets: setting + " = ?",
+		where: "serverID = ?",
+		values: [value, guild]
+	};
+	
+	await dbManager.Query(query);
+	
+	await reloadConfig(guild);
+	
+	// convert the value back for comparing
+	switch(cVal[setting]) {
+		case "integer":
+			value = parseInt(value,10);
+			break;
+		case "string":
+		  value = value.toString();
+			break;
+		case "array":
+			value = value === null ? null : value.split(",");
+		  break;
+		case "boolean":
+			value = !!value;
+			break;
+	}
+	if (
+	  (CONFIG.servers[guild][setting] === value) ||
+	  (
+			(JSON.stringify(CONFIG.servers[guild][setting]) === JSON.stringify(value)) &&
+		  (typeof CONFIG.servers[guild][setting] === (typeof value))
+		)
+	) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+async function reloadConfig(g) {
+	var rec = await dbManager.Query({"select": "config", "columns":["*"], "where": "serverID = ?", "orderby": "serverID", "values":[g]});
+	if (rec.length) {
+		rec.forEach((e) => {
+			CONFIG.servers[e.serverID.toString()] = e;
+		});
+		rec = {};
+		rec[g] = CONFIG.servers[g];
+		rec = HELPERS.convertDataFromDB(rec,"cfg");
+		CONFIG.servers[g] = rec[g];
+		return true;
+	}
+	return false;
+}
+
+async function handle(m) {
+	var guildService = require('../services/guildService');
+	var refreshedAuthorObj = await guildService.getMemberForceLoad(m.author.id);
+	if (!(
+		refreshedAuthorObj._roles.includes(CONFIG.servers[m.guild.id].botMasterRole) ||
+		m.member.permissions.has(1 << 3)
+	)) {
+		LOGGER.log("UNAUTHORIZED USAGE ATTEMPT: <@" + m.author.id + "> (" + m.author.tag + ") (" + m.author.id + ") Tried to use me with this command: " + m.content);
+		if (CONFIG.servers[m.guild.id].warnAuthorizedUsage)
+			m.channel.send("You don't have the rights to use me you filthy swine!");
+		return;
+	}
+	
+	return resolveCommand(m);
+}
+
+exports.handle = handle;
+//exports.injectConfig = injectConfig;
+exports.configure = configure;

--- a/src/commands/helpCommand.js
+++ b/src/commands/helpCommand.js
@@ -1,19 +1,23 @@
 
 const HELPERS = require('../helpers/helpers');
 
+/* DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
 var CONFIG;
 function injectConfig(_cfg) {
     CONFIG = _cfg;
 }
+*/
 
 async function handle(message) {
-    var help = "==help==" +
-        "\r\n" + CONFIG.commandPrefix +"tank - drunk tanks a user. usage: "+CONFIG.commandPrefix+"tank @user reason." +
-        "\r\n" + CONFIG.commandPrefix +"checktank - Checks the current users in the tank." +
-        "\r\n" + CONFIG.commandPrefix +"untank - Untank a user. usage: "+CONFIG.commandPrefix+"untank @user reason." +
-        "\r\n" + CONFIG.commandPrefix +"tankstats - Stats for fun. " +
-        "\r\n" + CONFIG.commandPrefix +"synctank - sync up the 2drunk2party role with the Bot tank log. " +        
-        "\r\n" + CONFIG.commandPrefix +"help - Sends this help message" +
+	  var prefix = CONFIG.servers[message.guild.id].commandPrefix;
+    var help = "==TankCommander Help==" +
+        "\r\n" + prefix + "tank - drunk tanks a user. usage: `" + prefix + "tank @user reason`" +
+        "\r\n" + prefix + "checktank - Checks the current users in the tank." +
+        "\r\n" + prefix + "untank - Untank a user. usage: `" + prefix + "untank @user [reason]`" +
+        "\r\n" + prefix + "tankstats - gets info of specific user or top 5 if not provided." +
+				"\r\n" + prefix + "config - configures various settings. Use `" + prefix + "config help` for more info." +
+        //"\r\n" + prefix +"synctank - sync up the 2drunk2party role with the Bot tank log. " + DEPRECATED AND REMOVED; uses DB now instead of DRP    
+        "\r\n" + prefix +"help - Sends this help message" +
         "\r\n" +
         "\r\n" + CONFIG.bot_name + " " + HELPERS.BOT_VERSION() + " by stevie_pricks & Sindrah";
 
@@ -22,4 +26,4 @@ async function handle(message) {
 }
 
 exports.handle = handle;
-exports.injectConfig = injectConfig;
+//exports.injectConfig = injectConfig;

--- a/src/commands/sipCommand.js
+++ b/src/commands/sipCommand.js
@@ -1,49 +1,78 @@
-
 const HELPERS = require('../helpers/helpers');
 var persistenceService = require('../services/persistenceService');
+
+/* DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
 var CONFIG;
 function injectConfig(_cfg) {
     CONFIG = _cfg;
 }
+*/
 
 async function handle(message) {
     var action = message.content.toLowerCase();
     var userId = message.author.id;
-    var nickname = message.author.username;
+	var mention = "<@" + userId + ">";
+    var guild = message.guild.id; // previously nickname, no longer necessary as message.author.nickname is available.
+    // The bot Writer doesn't normally sip on his offtime, and the bot respects that, mostly because the bot writer sips so much when coding the bot couldn't even count
+	// Output a special message inflating the bot writer's ego, and return out.
+	if (userId === "92092480073236480") {
+		message.channel.send("<@92092480073236480>, you sipped alcohol so much during my development, I'd wager it's well over 9000. I stopped counting your sips long ago.");
+		return;
+	}
+	// Don't allow sips in the tankChannel
+	if (message.channel.id === CONFIG.servers[message.guild.id].tankChannel) {
+		return;
+	}
+	var userObj = await persistenceService.addSip(guild, action, userId, message.createdTimestamp);
+		
+		var acting = action + action.substr(-1) + "ing";
+		var slowdowns = [
+		  "Hey! Slow down " + mention + ", this ain't a race!",
+			"I admire your enthusiasm for the art " + mention + ", but " + acting + " is a subtle practice you don't need to rush.",
+			"If you rush into " + acting + " this much, I don't wanna know what you do in your spare time. Try waiting a little bit between " + action + "s there " + mention + ".",
+			"Thought you'd get credit for spamming those " + action + "s so fast, did ya? Fat chance! Try slowing it down a bit " + mention + ".",
+			"Ya know " + mention + ", you really should wait a bit longer between " + action + "s."
+		];
+		var msgString;
+		
+		// Was the sip rejected for being too soon?
+		if ((userObj.slow !== undefined) && (userObj.slow)) {
+			msgString = HELPERS.fisherYates(slowdowns)[0];
+		} else {
+		
+			var trailing_s = ""
+			if (userObj[action] > 1) {
+					trailing_s = "s"
+			}
 
-    var userObj = persistenceService.addSip(action, userId, nickname);
+			msgString = "<@" + userObj.userId + 
+					"> has enjoyed " + userObj[action] + " " + action + trailing_s;
 
-    var trailing_s = ""
-    if (userObj.count > 1) {
-        trailing_s = "s"
-    }
+			if (userObj[action] % 69 == 0 || userObj[action] % 420 == 0) {
+					msgString += ". Nice.";
+			}
 
-    var msgString = HELPERS.getAtString(userObj.userID) + 
-        " has enjoyed " + userObj.count + " " + userObj.sipStr + trailing_s;
-
-    if (userObj.count % 69 == 0 || userObj.count % 420 == 0) {
-        msgString += ". Nice.";
-    }
-
-    if (userObj.count == 42) {
-        msgString = "Sipping 42 sips is the answer to the ultimate Question of life, the universe, and everything"
-    }
-    else if (userObj.count == 100) {
-        msgString = "100 " +userObj.sipStr +"s is a proud moment for any pisshead. ";
-    }
-    else if (userObj.count == 1000) {
-        msgString = "1000 " + userObj.sipStr + "s. That is impressive dedication to the art. Three cheers for " + HELPERS.getAtString(userObj.userID) + 
-            "! 🎉🎉🎉🎉🎉🎉";
-    }
-    else {
-        if (Math.floor((Math.random() * 100) + 1) == 50) {
-        //make one in every 100 say something else
-        msgString = "You take a sip from your trusty vault 13 canteen.";
-        }
-    }
-
+			if (userObj[action] == 42) {
+					msgString = action + "ing 42 " + action + "s is the answer to the ultimate Question of life, the universe, and everything.";
+			}
+			else if (userObj[action] == 100) {
+					msgString = "100 " + action +"s is a proud moment for any pisshead.";
+			}
+			else if (userObj.count == 1000) {
+					msgString = "1000 " + action + "s. That is impressive dedication to the art. Three cheers for <@" + userObj.userId + ">! 🎉🎉🎉🎉🎉🎉";
+			}
+			else {
+					if (Math.floor((Math.random()*100) + 1) == 50) {
+						//make one in every 100 say something else
+						switch (action) {
+							case "sip":
+								msgString = "You take a sip from your trusty vault 13 canteen.";
+						}
+					}
+			}
+		}
     message.channel.send(msgString);
 }
 
 exports.handle = handle;
-exports.injectConfig = injectConfig;
+//exports.injectConfig = injectConfig;

--- a/src/commands/sipStatsCommand.js
+++ b/src/commands/sipStatsCommand.js
@@ -3,44 +3,36 @@ var persistenceService = require('../services/persistenceService');
 var guildService = require('../services/guildService');
 const HELPERS = require('../helpers/helpers');
 
+/* DEPRECATED; CONFIG lives in global namespace of main.js
 var CONFIG;
 function injectConfig(_cfg) {
     CONFIG = _cfg;
 }
+*/
 
 async function handle(message) {
-    var allSips = persistenceService.getAllSips();
-
-    var msg = "";
-    for (i = 0; i < CONFIG.countedStrings.length; i++) {
-         sipStr = CONFIG.countedStrings[i];
-         var filteredArray = allSips.filter(x=> x.sipStr == sipStr);
-         var sortedArray = filteredArray.sort((a,b) => { return  b.count - a.count }).slice(0,5);
-
-         msg += "== " + sipStr + " Top 5 =="
-         for (n = 0; n <sortedArray.length; n++) {
-             x = sortedArray[n];
-             var str;
-             try { 
-                str = await guildService.getMemberFromCache(x.userID);
-                str = str.nickname;
-             } 
-             catch {
-                 str = HELPERS.getAtString(x.userID);
-             }
-             msg += "\r\n" + str + " - " + x.count;
-             if (x.count % 69 == 0 || x.count % 420 == 0) {
-                 msg += ". Nice.";
-             }
-         }
-         msg += "\r\n";
-         message.channel.send(msg);
-         msg = "";
-    }
-
-        
-   
+	var allSips = await persistenceService.getAllSips(message.guild.id);
+	var msg = "";
+	allSips.structure.forEach((c,k) => {
+		if ((c != "userId") && (c != "lastSip")) {
+			msg += msg === "" ? "" : "\r\n";
+			msg += "== " + c + " Top 5 ==";
+			allSips.data.sort((a,b) =>{
+				return b[c] - a[c];
+			});
+			for (i=0;i<5;i++) {
+				let u = allSips.data[i].userId;
+				u = guildService.getMemberFromCache(u);
+				let r = allSips.data[i][c];
+				msg += "\r\n" + (i + 1) + ". " + u.displayName + " (" + u.user.tag + ") - " + r;
+				if (allSips.data.length === i + 1) {
+					break;
+				}
+			}
+		}
+	});
+	message.channel.send(msg);
 }
 
 exports.handle = handle;
-exports.injectConfig = injectConfig;
+//exports.injectConfig = injectConfig;

--- a/src/commands/tankCommand.js
+++ b/src/commands/tankCommand.js
@@ -1,32 +1,33 @@
-
 var guildService = require('../services/guildService');
 var drunkTankService = require('../services/drunktankService');
 
 const HELPERS = require('../helpers/helpers');
 const MESSAGES = require('../helpers/messages');
 
+/* DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
 var CONFIG;
 function injectConfig(_cfg) {
     CONFIG = _cfg;
 }
+*/
 
 async function handle(message) {
     msg = HELPERS.trimMsg(message);
-
-    var tankedMemberId = message.mentions.users.first().id;
-    var author =  guildService.getMemberFromCache(message.author.id);
-    var role = await guildService.getRole(CONFIG.drunktankRole);
-
-    tokens = HELPERS.tokenize(msg.substr(1,msg.length -1 ));
-
-    //Validate token length
+		
+		tokens = HELPERS.tokenize(msg.substr(1,msg.length -1 ));
+		
+		//Validate token length
     if (tokens.length < 2) {
-        message.channel.send("Invalid arguments. Correct usage: " + CONFIG.commandPrefix + "tank @user reason");
+        message.channel.send("Invalid arguments. Correct usage: " + CONFIG.servers[message.guild.id].commandPrefix + "tank @user reason");
         return;
     }
+		
+    var tankedMember = guildService.getMemberFromCache(message.mentions.users.first().id);
+    var author = guildService.getMemberFromCache(message.author.id);
+    var role = await guildService.getRole(CONFIG.servers[message.guild.id].drunktankRole);
 
     //Check if we have to handle customized timings
-	var tankedFor = HELPERS.parseDurationFromTokens(tokens);
+		var tankedFor = HELPERS.parseDurationFromTokens(tokens, message.guild.id);
 
     //Get a reason
     var reason = HELPERS.getReason(tankedFor.newTokens);
@@ -35,18 +36,19 @@ async function handle(message) {
     if (!HELPERS.validateReason(reason, message)) {
         return;
     }
+		
     //Make sure we have a mention on the message
-    if (!HELPERS.validateMentions(message, "tank", CONFIG.commandPrefix)) {
+    if (!HELPERS.validateMentions(message, "tank")) {
         return;
     }
 
     //actually tank the user
-    return drunkTankService.tankUser(tankedMemberId, author.id, reason, tankedFor.duration, tankedFor.uom)
+    return drunkTankService.tankUser(message.guild.id, tankedMember, author, reason, tankedFor.duration, tankedFor.uom)
         .then( (roles) => {
-            msg = MESSAGES.confirm_message(author.nickname, HELPERS.getAtString(tankedMemberId), reason, role.name, roles.roles);
+            msg = MESSAGES.confirm_tank_message(author, tankedMember, reason, role.name, roles.roles);
             return message.channel.send(msg);
         });
 }
 
 exports.handle = handle;
-exports.injectConfig = injectConfig;
+//exports.injectConfig = injectConfig;

--- a/src/commands/tankStatsCommand.js
+++ b/src/commands/tankStatsCommand.js
@@ -1,15 +1,33 @@
+const HELPERS = require('../helpers/helpers');
+var tankStatsService = require('../services/tankStatsService');
 
-var tankStatsServcice = require('../services/tankStatsService');
-
+/* DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
 var CONFIG;
 function injectConfig(_cfg) {
     CONFIG = _cfg;
 }
+*/
 
 async function handle(message) {
-    var msg = await tankStatsServcice.getTankStatsStr();
-    message.channel.send(msg);
+	var user = HELPERS.trimMsg(message);
+	var tokens = HELPERS.tokenize(user.substr(1,user.length -1 ));
+	
+	//check token length
+	if (tokens.length < 2) {
+		user = false;
+	} else {
+		// A user handle or ID was passed with the command, we are looking for just this data
+		user = guildService.getMemberFromCache(message.mentions.users.first().id); // Mention Handle
+		if (!user) {
+		  user = guildService.getMemberFromCache(tokens[1]); // Using ID
+		}
+	}
+	
+	var json = await tankStatsService.filterTankStats(message.guild.id, user);
+	var msg = await tankStatsService.getTankStatsStr(json, user);
+	
+	message.channel.send(msg);
 }
 
 exports.handle = handle;
-exports.injectConfig = injectConfig;
+//exports.injectConfig = injectConfig;

--- a/src/commands/untankCommand.js
+++ b/src/commands/untankCommand.js
@@ -1,4 +1,3 @@
-
 var guildService = require('../services/guildService');
 var drunkTankService = require('../services/drunktankService');
 var persistenceService = require('../services/persistenceService');
@@ -6,44 +5,74 @@ var persistenceService = require('../services/persistenceService');
 const HELPERS = require('../helpers/helpers');
 const MESSAGES = require('../helpers/messages');
 
+/* DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
 var CONFIG;
 function injectConfig(_cfg) {
     CONFIG = _cfg;
 }
+*/
 
 async function handle(message) {
-    msg = HELPERS.trimMsg(message);
-
+		msg = HELPERS.trimMsg(message);
     tokens = HELPERS.tokenize(msg.substr(1,msg.length -1 ));
         
-    if (tokens.length < 1) {
-        message.channel.send("Invalid arguments. Correct usage: " + CONFIG.commandPrefix + "untank @user optionalreason");
+		//Validate token length
+    if (tokens[0] == "") {
+        message.channel.send("Invalid arguments. Correct usage: " + CONFIG.servers[message.guild.id].commandPrefix + "untank @user [reason]");
         return;
     }
-    var reason = HELPERS.getReason(tokens);
-    if (!HELPERS.validateMentions(message, "untank", CONFIG.commandPrefix)) {
-        return;
+		var tankedMember = message.mentions.users.size;
+    var bypassValidateMentions = false;
+    if (tankedMember === 0) {
+      // User left server before they were untanked, so we have to grab their id using a regex from the message content.
+      // The user ID is then utilized to obtain their GuildMemberObject. We also need to bypass validateMentions(), so we should set a variable for that.
+      bypassValidateMentions = true;
+      tankedMember = tokens[0].replace("<@!","").replace(">","");
+      tankedMember = {
+        id: tankedMember
+      };
+      tankedMember.user = await message.client.users.fetch(tankedMember.id);
+      //Write a unique log message to the blue log channel
+      await guildService.writeToChannel('logChannel', "<@" + message.author.id + "> untanked " + tankedMember.user.tag + "(" + tankedMember.id + "), but they are not in the server anymore.");
+      //Save the untanking directly, otherwise we get a rejection when trying to give them back any roles.
+      persistenceService.saveUntanking(message.guild.id, tankedMember.id, message.author.id, "Time served - Cleanup user not in server");
+      return;
+    } else {
+		  tankedMember = guildService.getMemberFromCache(message.mentions.users.first().id);
     }
-    if (reason.replace(/[^A-Za-z0-9]/g, '') == "") {
+    var author = guildService.getMemberFromCache(message.author.id);
+    var role = await guildService.getRole(CONFIG.servers[message.guild.id].drunktankRole);
+		//Get a reason
+		var reason = HELPERS.getReason(tokens);
+    
+		// reason is optional, default assume time served.
+		if (reason.replace(/[^A-Za-z0-9]/g, '') == "") {
         reason = "Default - assume time served.";
     }
-
-    var tankedMemberId = message.mentions.users.first().id;
-    var author =  guildService.getMemberFromCache(message.author.id);
-
-    userJson = persistenceService.getUser(tankedMemberId);
-
-    if (userJson == undefined){
-        //dont do anything if they are not in our log. we might strip them of their roles by accident.
-        return message.channel.send("User not found in tank log. Do it manually or run tanksync please.");
+		
+		//Make sure we have a mention on the message
+		if (!HELPERS.validateMentions(message, "untank")) {
+        return;
     }
 
-    return drunkTankService.untankUser(tankedMemberId, author.id, userJson)
+    userJson = await persistenceService.getTankedUsers(message.guild.id, true, tankedMember.id);
+		var isTanked = false;
+		Object.entries(userJson).forEach(([t,r]) => {
+			if (r.user_tanked === tankedMember.id) {
+				isTanked = r;
+			}
+		});
+    if (!isTanked){
+        //don't do anything if they are not in our log. we might strip them of their roles by accident.
+        return message.channel.send("User " + tankedMember.user.tag + " (" + tankedMember.id + ") not found in tank log. Do it manually.");
+    }
+
+    return await drunkTankService.untankUser(message.guild.id, tankedMember, author, isTanked, reason)
         .then((rolesGivenBack)=> {
-            msg = MESSAGES.confirm_untank_message(author.nickname, HELPERS.getAtString(tankedMemberId), reason, rolesGivenBack.roles);
+            msg = MESSAGES.confirm_untank_message(author, tankedMember, reason, role.name, rolesGivenBack.roles);
             return message.channel.send(msg);
         });
 }
 
 exports.handle = handle;
-exports.injectConfig = injectConfig;
+//exports.injectConfig = injectConfig;

--- a/src/config/druncord_linux.js
+++ b/src/config/druncord_linux.js
@@ -1,42 +1,13 @@
 require('dotenv').config();
-
-const drunktankRole = "753777735452852324";
-const tankChannel = "757031918628765806";
-const logChannel = "753778482844270605";
-const botMasterRole = "753412065456291901";
-const serverID = "795115424634372147";
-const tankUOM = "hours";
-const tankDuration = "12";
-const commandPrefix = ".";
 const access_key = process.env.druncord_access_key;
-const json_path = "tankees.json";
 const bot_name = "TankCommander";
-const bypassGMU = ['846086496028983296','821425253002903595','159985870458322944','850806881798324224'];//Bot itself, druncord, mee6 and role persistence
-const rolesToIgnore = ['756711648160645172']; //Roles that we do not try to remove or give
-const rolesICannotTank = ['753412065456291901']; //Roles that we cannot command
-const defaultStaffChat = "753779129740034209";
-const writeMessageToDrunkTank = false;
-const warnAuthorizedUsage = false;
-const countedStrings = ['sip'];
-const countedJsonPath = 'sipcount.json';
-
-
-exports.drunktankRole = drunktankRole
-exports.tankChannel = tankChannel
-exports.logChannel = logChannel
-exports.botMasterRole = botMasterRole
-exports.tankUOM = tankUOM
-exports.tankDuration = tankDuration
-exports.commandPrefix = commandPrefix
+const dbServer = {
+	host: process.env.db_host,
+  port: parseInt(process.env.db_port),
+  user: process.env.db_user,
+  password: process.env.db_pass,
+  database: process.env.db_database
+};
 exports.access_key = access_key
-exports.json_path = json_path
 exports.bot_name = bot_name
-exports.serverID = serverID
-exports.bypassGMU = bypassGMU
-exports.defaultStaffChat = defaultStaffChat
-exports.writeMessageToDrunkTank = writeMessageToDrunkTank;
-exports.warnAuthorizedUsage = warnAuthorizedUsage;
-exports.countedStrings = countedStrings;
-exports.countedJsonPath = countedJsonPath;
-exports.rolesICannotTank = rolesICannotTank;
-exports.rolesToIgnore = rolesToIgnore;
+exports.dbServer = dbServer;

--- a/src/events/inviteEvent.js
+++ b/src/events/inviteEvent.js
@@ -1,0 +1,34 @@
+var guildService = require('../services/guildService');
+var inviteService = require('../services/inviteService');
+
+const HELPERS = require('../helpers/helpers');
+const MESSAGES = require('../helpers/messages');
+
+/*
+Handle member leaving
+We want to remove them from the checktank list // NO LONGER NECESSARY
+CHANGED FUNCTIONALITY; now triggers all logging options on user leave
+*/
+async function handle(invite, old) {
+  var cfg = CONFIG.servers[invite.guild.id];
+	var msg = "";
+		
+	// is the invite new, or old?
+	if (old) {
+		// The invite is old, so it was a deleted invite. Update it in the DB and get its returned invite info.
+		// First, fetch the saved invite from db so we have the inviter ID.
+		let db_invite = await inviteService.getInvites(cfg.serverID);
+		db_invite[invite.code].code = invite.code;
+		db_invite = db_invite[invite.code];
+		let refreshedUserObj = await invite.client.users.fetch(db_invite.inviter);
+		refreshedInvite = await inviteService.updateInvite(cfg.serverID, db_invite, true);
+		msg += "Invite **" + refreshedInvite.code + "** deleted. It was " + (refreshedInvite.uses === null ? "never used." : (refreshedInvite.uses == 1 ? "used once." : "used " + refreshedInvite.uses + " times.")) + " It was created by <@" + refreshedUserObj.id + "> (" + refreshedUserObj.tag + ") (" + refreshedUserObj.id + ")";
+	} else {
+		// The invite was created, it has what we need
+		await inviteService.createInvite(cfg.serverID, invite);
+		msg += "Invite **" + invite.code + "** created by <@" + invite.inviter.id + "> (" + invite.inviter.tag + ") (" + invite.inviter.id + ")";
+	}
+	await guildService.writeToChannel('invitesChannel', msg);
+}
+
+exports.handle = handle;

--- a/src/events/memberJoinEvent.js
+++ b/src/events/memberJoinEvent.js
@@ -2,37 +2,77 @@
 var guildService = require('../services/guildService');
 var drunkTankService = require('../services/drunktankService');
 var persistenceService = require('../services/persistenceService');
-var syncTankService = require('../services/syncTankService');
+var inviteService = require('../services/inviteService');
+//var syncTankService = require('../services/syncTankService'); DEPRECATED AND REMOVED; uses DB now instead of DRP
 
 const HELPERS = require('../helpers/helpers');
 const MESSAGES = require('../helpers/messages');
 const LOGGER = require('../helpers/logger');
 
+/* DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
 var CONFIG;
 function injectConfig(_cfg) {
     CONFIG = _cfg;
 }
+*/
 
 /*
 Handle member joining
-we want to check if they have an outstanding tanking, and resume it
-This event assumes the role persistence bot has acted and they have 2drunk2party
+we want to check if they have an outstanding tanking, and resume it.
+Takes over Discord Role Persistence due to database logging.
 */
 async function handle(newMember) {
-    var user = persistenceService.getUserHistorical(newMember.id);
-
-    if (user == undefined) {
-        return;
-    }
-
-    //Update our records 
-    persistenceService.saveUserJoining(newMember.id);
-
-    //Sync the tank after 10 seconds to give the role persistence bot some time to catch up
-    return setTimeout(() => {
-        return syncTankService.syncTank();
-    }, 10000);
+	// First, handle the invite check.
+	let db_invites = await inviteService.getInvites(newMember.guild.id);
+  if (!Object.keys(db_invites).length) {
+		// We don't have any invites saved!
+		return await guildService.writeToChannel('logChannel',
+			"<@&" + CONFIG.servers[newMember.guild.id].botMasterRole + "> " +
+		  "You need to fill the invites table in the database with your invites!" +
+			"\r\nRun the command `" + CONFIG.servers[newMember.guild.id].commandPrefix + "config getinvites`"
+		);
+	}
+	let g_invites = await inviteService.getGuildInvites(newMember.guild);
+	let invite = null;
+	g_invites.forEach((i,k)=>{
+		let adjusted_uses = 0;
+		if (typeof db_invites[i.code].uses === "object") {
+			Object.entries(db_invites[i.code].uses).forEach(([u,t]) => {
+				adjusted_uses += t.length;
+			});
+			adjusted_uses += db_invites[i.code].dummies;
+		} else {
+			adjusted_uses = db_invites[i.code].uses;
+		}
+		if ( adjusted_uses === (i.uses - 1)) {
+			// Found the code that was used by this joining user.
+			invite = i;
+		}
+	});
+	// send join message
+	await guildService.writeToChannel("invitesChannel", MESSAGES.user_join_msg(newMember, invite));
+	// update the invite and add a usage
+	await inviteService.addInviteUse(newMember, invite);
+	
+	// Now, handle tank persistence
+	var user = await persistenceService.getTankedUsers(newMember.guild.id, true, newMember.id);
+	let isTanked = false;
+	Object.entries(user).forEach(([t,r]) => {
+		if (r.user_tanked === newMember.id) {
+			// This user was in the tank. Check if their time is up.
+			isTanked = r;
+		}
+	});
+	if (isTanked) {
+		if (Date.now() >= isTanked.time_to_untank) {
+			// Their time is up, call untank command.
+			let botMember = await guildService.getMemberForceLoad(newMember.client.id);
+			return await drunkTankService.untankUser(newMember.guild.id, newMember, botMember, isTanked, "Time served");
+		} else {
+			return await guildService.setRolesForMember(newMember.id, [CONFIG.servers[newMember.guild.id].drunktankRole]);
+		}
+	}
 }
 
 exports.handle = handle;
-exports.injectConfig = injectConfig;
+//exports.injectConfig = injectConfig;

--- a/src/events/memberLeaveEvent.js
+++ b/src/events/memberLeaveEvent.js
@@ -1,31 +1,70 @@
-
 var guildService = require('../services/guildService');
 var drunkTankService = require('../services/drunktankService');
 var persistenceService = require('../services/persistenceService');
+var inviteService = require('../services/inviteService');
 
 const HELPERS = require('../helpers/helpers');
 const MESSAGES = require('../helpers/messages');
 const LOGGER = require('../helpers/logger');
 
+/* DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
 var CONFIG;
 function injectConfig(_cfg) {
     CONFIG = _cfg;
 }
+*/
 
 
 /*
-Handle member joining
-We want to remove them from the checktank list
+Handle member leaving
+We want to remove them from the checktank list // NO LONGER NECESSARY
+CHANGED FUNCTIONALITY; now triggers all logging options on user leave
 */
-async function handle(oldMember) {
-    var user = persistenceService.getUser(oldMember.id);
-
-    if (user == undefined) {
-        return;
-    }
-
-    return persistenceService.saveUserLeaving(oldMember.id);
+async function handle(user) {	
+	// Get invites, discover who invited them if possible
+	let invites = await inviteService.getInvites(user.guild.id);
+	let invite = null;
+	Object.entries(invites).forEach(([k,i])=>{
+		if (typeof (i.uses) === "object") {
+			if (i.uses[user.id] !== undefined) {
+				// User has used this code before, is it their last used code?
+				if (i.uses[user.id].includes(user.joinedTimestamp)) {
+					invite = i;
+					invite.code = k;
+				}
+			}
+		}
+	});
+	
+	var ts = Date.now() - 5000;
+	
+	// Try to determine if the user was kicked, banned, or if they left on their own
+	let audit = await user.guild.fetchAuditLogs({limit: 3, type: 'MEMBER_KICK'});
+	for (let [key, value] of audit.entries) {
+		if ((value.target == user.id) && (value.createdTimestamp > ts)) {
+			user.leaveReason = "This user was kicked by <@" + value.executor + "> for " + (value.reason !== null ? value.reason : "a reason not specified.");
+		}
+	}
+	audit = await user.guild.fetchAuditLogs({limit: 3, type: 'MEMBER_BAN_ADD'});
+	for (let [key, value] of audit.entries) {
+		// Banned users need to have any open tanking record closed.
+		let tank = await persistenceService.getTankedUsers(user.guild.id, true, user.id);
+		if (JSON.stringify(tank) !== "{}") {
+			// A record was found for this userId that was still open. Untank them.
+			await drunkTankService.untankUser(user.guild.id, user, user.client, tank, "Banned");
+		}
+		// Handle the leave message
+		if ((value.target == user.id) && (value.createdTimestamp > ts)) {
+			user.leaveReason = "This user was banned by <@" + value.executor + "> for " + (value.reason !== null ? value.reason : "a reason not specified.");
+		}
+	}
+	if (user.leaveReason === undefined) {
+		// They weren't kicked, they left on their own
+		user.leaveReason = "This user left on their own.";
+	}
+	
+	await guildService.writeToChannel('invitesChannel', MESSAGES.user_leave_msg(user, invite));
 }
 
 exports.handle = handle;
-exports.injectConfig = injectConfig;
+//exports.injectConfig = injectConfig;

--- a/src/events/memberUpdateEvent.js
+++ b/src/events/memberUpdateEvent.js
@@ -1,4 +1,3 @@
-
 var guildService = require('../services/guildService');
 var drunkTankService = require('../services/drunktankService');
 var persistenceService = require('../services/persistenceService');
@@ -7,61 +6,134 @@ const HELPERS = require('../helpers/helpers');
 const MESSAGES = require('../helpers/messages');
 const LOGGER = require('../helpers/logger');
 
+/* DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
 var CONFIG;
 function injectConfig(_cfg) {
     CONFIG = _cfg;
 }
-
+*/
 
 /*
 Handle member changing
-this fires for loads of stuff, we are specifically only interested in roles
+this fires for loads of stuff, so filter what we want to look for
+// Looking for role changes and name changes only.
 */
-async function handle(oldMember, newMember) {
-	var oldRoles = oldMember._roles;
-	var newRoles = newMember._roles;
-    //check if the roles have changed
-    if (JSON.stringify(oldRoles) === JSON.stringify(newRoles)) {
-        LOGGER.log("Handled event with no role changes");
-        return;
-    }
 
-    //ensure any role changes involves 2drunk2party
-    if (!(oldRoles.includes(CONFIG.drunktankRole) || newRoles.includes(CONFIG.drunktankRole))) {
-        LOGGER.log("Handled role change event that didn't involve 2drunk2party.");
-        return;
-    }
+async function handle(oldMember, newMember, event) {
+	var namechange = false;
+	var change = {o:"",n:""};
+	var rolechange = false;
+	
+	// check if event fired from userUpdate or guildMemberUpdate
+	if (event === "userUpdate") {
+		// check only their username tag. Too many things fire for this.
+		if (oldMember.tag !== newMember.tag) {
+			// Actual Username/tag changed
+			namechange = "Username Altered\r\n";
+			change.o = oldMember.tag;
+			change.n = newMember.tag;
+		}
+	} else if (event === "guildMemberUpdate") {
+		if (oldMember.nickname !== newMember.nickname) {
+			// Nickname set, updated, or removed.
+			if (oldMember.nickname === null) {
+				namechange = "Nickname Added\r\n";
+				change.o = "";
+				change.n = newMember.nickname;
+			} else if (newMember.nickname === null) {
+				namechange = "Nickname Removed\r\n";
+				change.o = oldMember.nickname;
+				change.n = "";
+			} else {
+				namechange = "Nickname Changed\r\n";
+				change.o = oldMember.nickname;
+				change.n = newMember.nickname;
+			}
+		}
+	}
+	// Was there a name change?
+	if (namechange) {
+		return guildService.writeToChannel('namesChannel',MESSAGES.user_name_change_msg(oldMember, namechange, change));
+	}
+	
+	// Get back into guildMemberUpdate so we don't error out with userUpdate looking for a guild
+	if (event === "guildMemberUpdate") {
+		// Check role changes
+		var oldRoles = oldMember._roles;
+		var newRoles = newMember._roles;
+		//check if the roles have changed
+		if (JSON.stringify(oldRoles) === JSON.stringify(newRoles)) {
+				//LOGGER.log("Handled event with no role changes");
+				return;
+		}
+		
+		// Identify the role.
+		var role = null;
+		oldRoles.forEach((r,i) => {
+			if (newRoles.indexOf(r) === -1) {
+				role = r;
+			}
+		});
+		if (role === null) {
+			newRoles.forEach((r,i) => {
+				if (oldRoles.indexOf(r) === -1) {
+					role = r;
+				}
+			});
+		}
+		
+		guildService.getExecutorForRoleChangeFromAuditLog(role, oldMember.id)
+		
+		.then(async (responseObj) => {
+				guild = newMember.guild.id;
+				author = guildService.getMemberFromCache(responseObj.authorId);
+				auditAction = responseObj.auditAction;
+				// For drunktankRole only
+				duration = CONFIG.servers[oldMember.guild.id].tankDuration;
+				uom = CONFIG.servers[oldMember.guild.id].tankUOM;
+				reason = "Manual ";
+				
+				if (role !== CONFIG.servers[oldMember.guild.id].drunktankRole) {
+					// If it wasn't drunktankRole, we are logging who did it into the modlog.
+					return await guildService.writeToChannel("modlogChannel", MESSAGES.log_role_change(author, newMember, role, auditAction));
+				}
 
-    guildService.getExecutorForRoleChangeFromAuditLog(CONFIG.drunktankRole, oldMember.id)
-        .then((responseObj) => {
-            tankedUserId = newMember.user.id;
-            authorId = responseObj.authorId;
-            duration = CONFIG.tankDuration;
-            uom = CONFIG.tankUOM;
-            auditAction = responseObj.auditAction;
-            reason = "";
-    
-            // Drunktank Role is involved in this audit log for the affected user, and not done by a bypassing User.
-            if (oldRoles.includes(CONFIG.drunktankRole) && 
-                !newRoles.includes(CONFIG.drunktankRole) &&
-                auditAction === "$remove") {
-                //Looks like 2Drunk2Party was removed
-                tankedUserJson = persistenceService.getUser(tankedUserId); 
-                return drunkTankService.untankUser(tankedUserId, authorId, tankedUserJson);
-    
-            } 
-            if (!oldRoles.includes(CONFIG.drunktankRole) && 
-                newRoles.includes(CONFIG.drunktankRole) && 
-                auditAction === "$add")	{
-                //Looks like 2Drunk2Party was added 
-                return drunkTankService.tankUser(tankedUserId, authorId, reason, duration, uom);
-            }
-        })
-        .catch((ex) => {
-            LOGGER.log("exception: " + ex);
-            LOGGER.log("2Drunk2Party was added or removed but we couldn't find the audit log.");
-        });
+				// Drunktank Role is involved in this audit log for the affected user, and not done by a bypassing User.
+				if (oldRoles.includes(CONFIG.servers[oldMember.guild.id].drunktankRole) && 
+						!newRoles.includes(CONFIG.servers[oldMember.guild.id].drunktankRole) &&
+						auditAction === "$remove") {
+						//Looks like 2Drunk2Party was removed
+						tankedUserJson = await persistenceService.getTankedUsers(oldMember.guild.id,true,oldMember.id);
+						correctUser = false;
+						Object.entries(tankedUserJson).forEach(([timetanked,tUserObj]) => {
+							if (tUserObj.user_tanked === oldMember.id) {
+								// This record is for the correct user that is still in the tank
+								reason += "untanking";
+								correctUser = true;
+								tankedUserJson = tUserObj;
+							}
+						});
+						if (correctUser) {
+							return await drunkTankService.untankUser(guild, newMember, author, tankedUserJson, reason);
+						} else {
+							throw "User was not found in the tank!";
+						}
+				} 
+				if (!oldRoles.includes(CONFIG.servers[oldMember.guild.id].drunktankRole) && 
+						newRoles.includes(CONFIG.servers[oldMember.guild.id].drunktankRole) && 
+						auditAction === "$add")	{
+						//Looks like 2Drunk2Party was added
+						reason += 'tanking';
+						return drunkTankService.tankUser(guild, newMember, author, reason, duration, uom);
+				}
+		})/*
+		.catch((ex) => {
+				LOGGER.log("exception: " + ex);
+				LOGGER.log(role + " was added or removed but we couldn't find the audit log for server " + oldMember.guild.id + ".");
+		})*/;
+	}
+	return;
 }
 
 exports.handle = handle;
-exports.injectConfig = injectConfig;
+//exports.injectConfig = injectConfig;

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -1,9 +1,22 @@
+/* DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
 var CONFIG;
-
-function injectConfig(myConfig) {
-    CONFIG = myConfig;
+function injectConfig(_cfg) {
+    CONFIG = _cfg;
 }
+*/
+
 var moment = require('moment');
+
+function fisherYates(arr) {
+	for (var i = arr.length - 1; i > 0; i--) {
+		const swapIndex = Math.floor(Math.random() * (i + 1));
+		const currentIndex = arr[i];
+		const indexToSwap = arr[swapIndex];
+		arr[i] = indexToSwap;
+		arr[swapIndex] = currentIndex;
+	}
+	return arr;
+}
 
 function getDateDiffString(future, past) {
     var mPast = moment(past);
@@ -48,20 +61,32 @@ function getReason(tokens) {
 }
 function validateReason(reason, message) {
     if (reason.replace(/[^A-Za-z0-9]/g, '') == "") {
-        message.channel.send("Invalid arguments. You must enter a reason. Correct usage: " + CONFIG.commandPrefix + "tank @user reason");
+        message.channel.send("Invalid arguments. You must enter a reason. Correct usage: " + CONFIG.servers[message.guild.id].commandPrefix + "tank @user reason");
         return false;
     }
     return true;
 }
 
-function validateMentions(message, command, prefix) {
+function validateMentions(message, command) {
+	  let r;
+		switch (command) {
+		  case "tank":
+			  r = " reason";
+				break;
+		  case "untank":
+			  r = " [reason]";
+				break;
+			default:
+				r = "";
+		}
+		
     if (message.mentions.users.size == 0) {
-        message.channel.send("Invalid arguments. You need to @ the user to drunk tank them. Correct usage: " + prefix + command + " @user reason");
+        message.channel.send("Invalid arguments. You need to @ the user to use this command. \r\nCorrect usage: " + CONFIG.servers[message.guild.id].commandPrefix + command + " @user" + r);
         return false;
     }
 
     if (message.mentions.users.size > 1) {
-        message.channel.send("Invalid arguments. More than one user @'d - only @ the user you are tanking. Correct usage: " + prefix + command + " @user reason");
+        message.channel.send("Invalid arguments. More than one user @mentioned.\r\nCorrect usage:" + CONFIG.servers[message.guild.id].commandPrefix + command + " @user " + r);
         return false;
     }
 
@@ -74,31 +99,20 @@ function tokenize(m) {
 
 function trimCommand(message) {
     let command = message.content.toLowerCase().split(" ")[0];
-    command = command.slice(CONFIG.commandPrefix.length);
+    command = command.slice(CONFIG.servers[message.guild.id].commandPrefix.length);
     return command;
 }
 
 function trimMsg(message) {
     let command = message.content.toLowerCase().split(" ")[0];
-    msg =  message.content.slice(command.length); 
+    msg = message.content.slice(command.length); 
     return msg;
 }
 
-function doesUserHaveRole(userObj, roleId) {
-    var retval = false;
-
-    for (n=0;n<userObj.roles.length;n++) {
-        if (userObj.roles[n] == roleId) {
-            retval = true;
-        }
-    }
-    return retval;
-}
-
-function parseDurationFromTokens(tokens) {
+function parseDurationFromTokens(tokens, guild) {
     // For finding the possible existence of a specified duration/UoM, we have to set the defaults first found in config. All references to the config defaults must be swapped over to these new local-scope variables.
-    var specifiedDuration = CONFIG.tankDuration; // "12"
-    var specifiedUOM = CONFIG.tankUOM; // "hours"
+    var specifiedDuration = CONFIG.servers[guild].tankDuration; // "12"
+    var specifiedUOM = CONFIG.servers[guild].tankUOM; // "hours"
     var mins = /^\d+m$/; // regex matches 1+ digits then an 'm' for minutes
     var hrs = /^\d+h$/; // regex matches 1+ digits then an 'h' for hours
     var days = /^\d+d$/; // regex matches 1+ digits then a 'd' for days
@@ -128,6 +142,7 @@ function parseDurationFromTokens(tokens) {
     }
 }
 
+// DEPRECATED AND REMOVED; Unnecessary, can be done inline with less code usage.
 function getAtString(userId) {
     return "<@"+userId+">";
 }
@@ -137,13 +152,15 @@ function getOldRoles(tankedMember){
 } 
 
 function removeRoleFromArray(roleArray, roleIdToRemove) {
-    for( var i = 0; i < roleArray.length; i++){ 
-        if (roleArray[i] === roleIdToRemove) { 
-            roleArray.splice(i, 1); 
-            return roleArray;
-        }
+    if (roleArray == undefined) {
+        return [];
     }
-    return roleArray;
+    roleArray.forEach((o,i) => {
+			if (o === roleIdToRemove) {
+				roleArray.splice(i,1);
+			}
+		});
+		return roleArray;
 }
 
 async function convertRoleIdArrayToRoleNameArray(rolesToConvert, guildService) {
@@ -168,11 +185,54 @@ function getBotVersion() {
     return pjson.version;
 }
 
+function convertDataFromDB(data,method) {
+	var tmp = {};
+	if (method === "cfg") {
+		Object.entries(data).forEach(([i,o]) => {
+			tmp[i.toString()] = {};
+			tmp[i.toString()].serverID = o.serverID.toString();
+			tmp[i.toString()].commandPrefix = o.commandPrefix.toString();
+			tmp[i.toString()].botMasterRole = o.botMasterRole === null ? null : o.botMasterRole.toString();
+			tmp[i.toString()].botUserRole = o.botUserRole === null ? null : o.botUserRole.toString();
+			tmp[i.toString()].drunktankRole = o.drunktankRole === null ? null : o.drunktankRole.toString();
+			tmp[i.toString()].tankChannel = o.tankChannel === null ? null : o.tankChannel.toString();
+			tmp[i.toString()].logChannel = o.logChannel === null ? null : o.logChannel.toString();
+			tmp[i.toString()].invitesChannel = o.invitesChannel === null ? null : o.invitesChannel.toString();
+			tmp[i.toString()].namesChannel = o.namesChannel === null ? null : o.namesChannel.toString();
+			tmp[i.toString()].modlogChannel = o.modlogChannel === null ? null : o.modlogChannel.toString();
+			tmp[i.toString()].bypassGMU = o.bypassGMU.split(",");
+			tmp[i.toString()].rolesToIgnore = o.rolesToIgnore === null ? null : o.rolesToIgnore.split(",");
+			tmp[i.toString()].rolesICannotTank = o.rolesICannotTank === null ? null : o.rolesICannotTank.split(",");
+			tmp[i.toString()].tankUOM = o.tankUOM.toString();
+			tmp[i.toString()].tankDuration = parseInt(o.tankDuration, 10);
+			tmp[i.toString()].writeMessageToDrunkTank = !!o.writeMessageToDrunkTank;
+			tmp[i.toString()].warnAuthorizedUsage = !!o.warnAuthorizedUsage;
+			tmp[i.toString()].startServer = !!o.startServer;
+		});
+	}
+	if (method === "tank") {
+		Object.entries(data).forEach(([i,o]) => {
+			tmp[i.toString()] = {};
+			tmp[i.toString()].time_tanked = o.time_tanked;
+			tmp[i.toString()].user_tanked = o.user_tanked.toString();
+			tmp[i.toString()].tanked_by = o.tanked_by.toString();
+			tmp[i.toString()].tank_reason = o.tank_reason;
+			tmp[i.toString()].time_to_untank = o.time_to_untank;
+			tmp[i.toString()].roles_to_give_back = o.roles_to_give_back.split(",");
+			tmp[i.toString()].untanked_by = o.untanked_by === null ? null : o.untanked_by.toString();
+			tmp[i.toString()].time_untanked = o.time_untanked === null ? null : o.time_untanked;
+			tmp[i.toString()].untanked_reason = o.untanked_reason === null ? null : o.untanked_reason;
+		});
+	}
+	return tmp;
+}
+
+exports.fisherYates = fisherYates;
 exports.getTopFive = getTopFive;
 exports.convertRoleIdArrayToRoleNameArray = convertRoleIdArrayToRoleNameArray;
 exports.removeRoleFromArray = removeRoleFromArray;
 exports.getOldRoles = getOldRoles;
-exports.getAtString = getAtString;
+//exports.getAtString = getAtString; // DEPRECATED AND REMOVED
 exports.parseDurationFromTokens = parseDurationFromTokens;
 exports.getDateDiffString = getDateDiffString;
 exports.getReason = getReason;
@@ -181,6 +241,7 @@ exports.validateMentions = validateMentions;
 exports.tokenize = tokenize;
 exports.trimCommand = trimCommand;
 exports.trimMsg = trimMsg;
-exports.injectConfig = injectConfig;
-exports.doesUserHaveRole = doesUserHaveRole;
+//exports.injectConfig = injectConfig;
+//exports.doesUserHaveRole = doesUserHaveRole; DEPRECATED AND REMOVED; uses inline ._roles.includes(roleId);
+exports.convertDataFromDB = convertDataFromDB;
 exports.BOT_VERSION = getBotVersion;

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -1,42 +1,83 @@
-function confirm_message(authorNickname, tankTaggedString, reason, drunktankRole, roles) {
-    return authorNickname + 
-    "\r\nCommanded me to drunk tank " + tankTaggedString +
+var moment = require('moment');
+const HELPERS = require('./helpers');
+
+function confirm_tank_message(author, tankedMember, reason, drunktankRole, roles) {
+    return author.displayName +
+    "\r\nCommanded me to drunk tank " + tankedMember.displayName +
     "\r\nWith Reason: " + reason +
     "\r\nI have removed all their roles: " + roles +
     "\r\nI have granted: " + drunktankRole;
 }
-function confirm_untank_message(authorNickname, tankTaggedString, reason, rolesGivenBack) {
-    return authorNickname + 
-    "\r\nCommanded me to untank " + tankTaggedString +
+function confirm_untank_message(author, tankedMember, reason, drunktankRole, rolesGivenBack) {
+    return author.displayName + 
+    "\r\nCommanded me to untank " + tankedMember.displayName +
     "\r\nWith Reason: " + reason +
-    "\r\nI have removed 2Drunk2Party, and returned their original roles: " + rolesGivenBack;
+    "\r\nI have removed " + drunktankRole + ", and returned their original roles: " + rolesGivenBack;
 }
-function log_blue_tank_msg(authorNickname, tankTaggedString, tankedUsername, tankedUserID, reason, disconnectedFromVc) {
+function log_blue_tank_msg(author, tankedMember, reason, roles, disconnectedFromVc) {
     return "=== DRUNK TANKED ===" +
-    "\r\Tag: " + tankTaggedString +
-    "\r\nUsername: " + tankedUsername +
-    "\r\nId: " + tankedUserID +
-    "\r\nDrunk tanked by " + authorNickname +
+    "\r\Tag: <@" + tankedMember.id + ">" +
+    "\r\nUsername: " + tankedMember.user.tag +
+    "\r\nId: " + tankedMember.id +
+    "\r\nDrunk tanked by <@" + author.id + "> (" + author.user.tag + ") (" + author.id + ")" +
     (disconnectedFromVc ? "\r\nI disconnected the member from VC" : "") +
-    (reason != "" ? "\r\nReason: " + reason : "");
+    "\r\nReason: " + reason;
 }
-function log_blue_untank_msg(authorNickname, tankTaggedString, tankedUsername, tankedUserID, datediff) {
+function log_blue_untank_msg(author, tankedUser, reason, datediff) {
     return "=== UNTANKED ===" +
-    "\r\Tag: " + tankTaggedString +
-    "\r\nUsername: " + tankedUsername +
-    "\r\nId: " + tankedUserID +
-    "\r\nUntanked by " + authorNickname +
+    "\r\Tag: <@" + tankedUser.id + ">" +
+    "\r\nUsername: " + tankedUser.user.tag +
+    "\r\nId: " + tankedUser.id +
+    "\r\nUntanked by <@" + author.id + "> (" + author.user.tag + ") (" + author.id + ")" +
+		"\r\nReason: " + reason;
     "\r\nThey were in the tank for " + datediff;
 }
-function tank_msg(authorNickname, tankTaggedString, reason, duration, uom) {
-    return tankTaggedString + "," +
-    "\r\nYou were drunk tanked by " + authorNickname + 
+function tank_msg(author, tankedMember, reason, duration, uom) {
+    return "<@" + tankedMember.id + ">," +
+    "\r\nYou were drunk tanked by " + author.displayName + 
     "\r\nReason: " + reason + 
     "\r\nYou are here for " + duration + " " + uom 
 }
 
+function user_leave_msg(oldMember, invite) {
+		return "<@" + oldMember.id + "> (" + oldMember.user.tag + ") (" + oldMember.id + ") **LEFT**" +
+		"\r\nInvited by " + (invite !== null ? "<@" + invite.inviter + "> (" + invite.inviter + ") with code **" + invite.code + "**" : "-Unknown-") +
+		"\r\nThe user account was created " + moment(oldMember.user.createdAt).format("MMM D, YYYY @ HH:mm:ss UTC") + " (" + HELPERS.getDateDiffString(Date.now(), oldMember.user.createdAt) + " ago)" +
+		"\r\nThe user was in the server for " + (oldMember.joinedTimestamp !== "unknown" ? HELPERS.getDateDiffString(Date.now(), oldMember.joinedTimestamp) : "an unknown time (needs manual lookup)") +
+    "\r\n" + oldMember.leaveReason;
+		
+}
+
+function user_join_msg(member, invite) {
+		return "<@" + member.id + "> (" + member.user.tag + ") (" + member.id + ") JOINED" +
+		"\r\nInvited by " + (invite !== null ? "<@" + invite.inviter + "> (" + invite.inviter + ") with code **" + invite.code + "**" : "-Unknown-") +
+		"\r\nThe user account was created " + moment(member.user.createdAt).format("MMM D, YYYY @ HH:mm:ss UTC") + " (" + HELPERS.getDateDiffString(Date.now(), member.user.createdAt) + " ago)";
+}
+
+function user_name_change_msg(oldMember, namechange, change) {
+		return "<@" + oldMember.id + "> (" + oldMember.id + ")\r\n" +
+			" - Change: " + namechange +
+			" - Old: " + change.o + "\r\n" +
+			" - New: " + change.n;
+}
+
+function log_role_change(author, newMember, role, auditAction) {
+	if (auditAction === '$add') {
+		return "<@" + author.id + "> (" + author.user.tag + ") (" + author.id + ") gave <@&" + role + "> to <@" + newMember.id + "> (" + newMember.user.tag + ") (" + newMember.id + ").";
+	}
+	if (auditAction === '$remove') {
+		return "<@" + author.id + "> (" + author.user.tag + ") (" + author.id + ") took <@&" + role + "> from <@" + newMember.id + "> (" + newMember.user.tag + ") (" + newMember.id + ").";
+	}
+	return "<@" + author.id + "> (" + author.user.tag + ") (" + author.id + ") modified somehow <@&" + role + "> from <@" + newMember.id + "> (" + newMember.user.tag + ") (" + newMember.id + ") (AuditLog entry missing)";
+	
+}
+
 exports.confirm_untank_message = confirm_untank_message;
-exports.confirm_message = confirm_message;
+exports.confirm_tank_message = confirm_tank_message;
 exports.log_blue_untank_msg = log_blue_untank_msg;
 exports.log_blue_tank_msg = log_blue_tank_msg;
 exports.tank_msg = tank_msg;
+exports.user_leave_msg = user_leave_msg;
+exports.user_join_msg = user_join_msg;
+exports.user_name_change_msg = user_name_change_msg;
+exports.log_role_change = log_role_change;

--- a/src/main.js
+++ b/src/main.js
@@ -1,89 +1,192 @@
 // ==========================================================
 // =========== Setup our app and Configure ==================
 // ==========================================================
-//Setup CONFIG file
+//Setup CONFIG_FILE file
 if (process.argv.length < 3) {
     //Assume default config
-    configfile = "testcfg";
+    configfile = "druncord_linux";
 }
 else {
     configfile = process.argv[2];
 }
 
-//instantiate all our services
-var guildService = require('./services/guildService.js');
-var persistenceService = require('./services/persistenceService');
-var drunkTankService = require('./services/drunktankService');
-var tankStatsService = require('./services/tankStatsService');
-var syncTankService = require('./services/syncTankService');
-var commandParser = require('./commands/commandParser');
-
 //Pull in our functional objects as constants
-const CONFIG = require('./config/' + configfile);
+const CONFIG_FILE = require('./config/' + configfile);
 const HELPERS = require('./helpers/helpers');
 
-//Connect up all our services & CONFIGure them
-drunkTankService.injectConfig(CONFIG);
-persistenceService.injectConfig(CONFIG);
-guildService.injectConfig(CONFIG);
-commandParser.injectConfig(CONFIG);
-syncTankService.injectConfig(CONFIG);
-tankStatsService.injectConfig(CONFIG);
+//instantiate our db connection manager
+var dbManager = require('./managers/dbConnectionManager.js');
 
-HELPERS.injectConfig(CONFIG);
+//if the db is unavailable, we cannot proceed
+var serverCONFIGquery = {"select": "config", "columns":["*"], "where": "?", "orderby": "serverID", "values":[1]};
+global.CONFIG = {servers:{},dbServer: CONFIG_FILE.dbServer, bot_name: CONFIG_FILE.bot_name};
+global.RETORTS = {"select": "retorts", "columns":["*"], "where": "?", "values":[1]};
+async function start() {
+	rec = await dbManager.Query(serverCONFIGquery);
+	rec.forEach((e) => {
+		CONFIG.servers[e.serverID.toString()] = e;
+	});
+	CONFIG.servers = HELPERS.convertDataFromDB(CONFIG.servers,"cfg");
+	
+	rec = await dbManager.Query(RETORTS);
+	RETORTS = [];
+	rec.forEach((e) => {
+		RETORTS.push(e.line);
+	});
+}
+start().then(async () =>{
+	//instantiate all our services
+	var bufferService = require('./services/bufferService');
+	var guildService = require('./services/guildService.js');
+	var persistenceService = require('./services/persistenceService');
+	var drunkTankService = require('./services/drunktankService');
+	var tankStatsService = require('./services/tankStatsService');
+	var inviteService = require('./services/inviteService');
+	//var syncTankService = require('./services/syncTankService'); DEPRECATED AND REMOVED; uses DB now instead of DRP
+	var commandParser = require('./commands/commandParser');
 
-//Log into our discord client
-const Discord = require("discord.js");
-const client  = new Discord.Client({
-    ws: { intents: Discord.Intents.ALL } 
-});
-client.login(CONFIG.access_key);
+	/*Connect up all our services & CONFIGure them -- DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
+	bufferService.injectConfig(CONFIG);
+	drunkTankService.injectConfig(CONFIG);
+	persistenceService.injectConfig(CONFIG);
+	guildService.injectConfig(CONFIG);
+	commandParser.injectConfig(CONFIG);
+	//syncTankService.injectConfig(CONFIG); DEPRECATED AND REMOVED; uses DB now instead of DRP
+	tankStatsService.injectConfig(CONFIG);
 
-//Notify we are starting up
-console.log(CONFIG.bot_name + " " + HELPERS.BOT_VERSION() + " starting up");
-console.log("Configuration: " + configfile);
+	HELPERS.injectConfig(CONFIG);
+  */
+	
+	//Log into our discord client
+	const Discord = require("discord.js");
+	// Possibly include a global of Permissions from Discord.js
+	const client  = new Discord.Client({
+		ws: { intents: Discord.Intents.ALL } 
+	});
+	client.login(CONFIG_FILE.access_key);
+
+	//Notify we are starting up
+	console.log(CONFIG_FILE.bot_name + " " + HELPERS.BOT_VERSION() + " starting up");
+	console.log("Configuration: " + configfile);
 
 
-// ==========================================================
-// ==============Discord Client Events=======================
-// ==========================================================
-client.on("ready", () => {
-    console.log(CONFIG.bot_name + " successfully started.");
-});
+	// ==========================================================
+	// ==============Discord Client Events=======================
+	// ==========================================================
+	client.on("ready", () => {
+		console.log(CONFIG_FILE.bot_name + " successfully started.\r\nReady!");
+	});
 
-//When an existing member is changed on the server
-client.on("guildMemberUpdate", async (o,n) => {
-    guildService.injectGuild(o.guild);
+	//// Default response in unconfigured server should be to run configure command.
+	// Each event/command trigger should check the server for existing configuration
+	async function serverConfigured(g,m) {
+		if (
+		(CONFIG.servers[g.id] == undefined) ||
+		(CONFIG.servers[g.id].botMasterRole === null) ||
+		(CONFIG.servers[g.id].botUserRole === null) ||
+		(CONFIG.servers[g.id].drunktankRole === null) ||
+		(CONFIG.servers[g.id].logChannel === null) ||
+		(CONFIG.servers[g.id].tankChannel === null) ||
+		(CONFIG.servers[g.id].invitesChannel === null) ||
+		(CONFIG.servers[g.id].namesChannel === null) ||
+		(CONFIG.servers[g.id].modlogChannel === null) ||
+		(CONFIG.servers[g.id].startServer === false)
+		) {
+			if (!m) {
+				let ch = g.channels.cache.get(g.systemChannelID);
+				ch.send("This server hasn't been configured yet. Use the command `.configure` in a secure channel to begin configuration.");
+			}
+			return false;
+		}
+		return true;
+	}
+	//When a server invite is created
+	client.on("inviteCreate", async (invite) => {
+		if (serverConfigured(invite.guild)) {
+			guildService.injectGuild(invite.guild);
+			var command = require('./events/inviteEvent');
+			//command.injectConfig(CONFIG); DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
+			return command.handle(invite, false);
+		}
+	});
+	
+	//When a server invite is deleted
+	client.on("inviteDelete", async (invite) => {
+		if (serverConfigured(invite.guild)) {
+			guildService.injectGuild(invite.guild);
+			var command = require('./events/inviteEvent');
+			//command.injectConfig(CONFIG); DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
+			return command.handle(invite, true);
+		}
+	});
+	
+	//When an existing user is changed on the server
+	client.on("userUpdate", async (o,n) => {
+		// Only record username changes and only in servers the user can be found in
+		var servers = [];
+		Object.entries(CONFIG.servers).forEach(([serverID,cfg]) => {
+			servers.push(serverID);
+		});
+		var command = require('./events/memberUpdateEvent');
+		for (i = 0; i < servers.length; i++) {
+			// Loop through each server. If configured, fetch guildMember of altered user,
+			// then call memberUpdateEvent for userUpdate using that server.
+			let guild = await o.client.guilds.fetch(servers[0]);
+			if (serverConfigured(guild)) {
+				guildService.injectGuild(guild);
+				// is user in this guild?
+				let guildMember = await guildService.getMemberForceLoad(o.id);
+				if ((guildMember !== null) && (guildMember !== undefined)) {
+					await command.handle(o,n, "userUpdate");
+				}
+			}
+		}
+		return;
+	});
+	
+	//When an existing member is changed on the server
+	client.on("guildMemberUpdate", async (o,n) => {
+		if (serverConfigured(o.guild)) {
+			guildService.injectGuild(o.guild);
+			var command = require('./events/memberUpdateEvent');
+			//command.injectConfig(CONFIG); DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
+			return command.handle(o,n,"guildMemberUpdate");
+		}
+	});
 
-    var command = require('./events/memberUpdateEvent');
-    command.injectConfig(CONFIG);
-
-    return command.handle(o,n);
-});
-
-//When a member joins the server
-client.on("guildMemberAdd", async (o) => {
-    guildService.injectGuild(o.guild);
-
-    var command = require('./events/memberJoinEvent');
-    command.injectConfig(CONFIG);
-
-    return command.handle(o);
-});
-
-//When a member leaves the server
-client.on("guildMemberRemove", async (o) => {
-    guildService.injectGuild(o.guild);
-
-    var command = require('./events/memberLeaveEvent');
-    command.injectConfig(CONFIG);
-
-    return command.handle(o);
-});
-
-//When a message is sent to the server
-client.on("message", async  (message) => {
-    guildService.injectGuild(message.guild);
-
-    return commandParser.parseCommand(message);
+	//When a member joins the server
+	client.on("guildMemberAdd", async (o) => {
+		if (serverConfigured(o.guild)) {
+			guildService.injectGuild(o.guild);
+			var command = require('./events/memberJoinEvent');
+			//command.injectConfig(CONFIG); DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
+			return command.handle(o);
+		}
+	});
+	
+	//When a member leaves the server
+	client.on("guildMemberRemove", async (o) => {
+		if (serverConfigured(o.guild)) {
+			guildService.injectGuild(o.guild);
+			var command = require('./events/memberLeaveEvent');
+			//command.injectConfig(CONFIG); DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
+			return command.handle(o);
+		}
+	});
+	
+	//When a message is sent to the server
+	client.on("message", async  (message) => {
+		if (!message.guild) {
+			if (message.author.id !== client.user.id) {
+				let msg = HELPERS.fisherYates(RETORTS);
+				return message.channel.send(msg[0]);
+			}
+		} else {
+			if (message.author.id !== client.user.id) {
+				// Prevents endless looped responses and checking on our own messages.
+				guildService.injectGuild(message.guild);
+				return commandParser.parseCommand(message,serverConfigured(message.guild,true));
+			}
+		}
+	});
 });

--- a/src/managers/dbConnectionManager.js
+++ b/src/managers/dbConnectionManager.js
@@ -1,0 +1,43 @@
+async function Query(query, getFields){
+	const mysql = require('mysql2/promise');
+	const con = await mysql.createConnection(CONFIG.dbServer);	
+	
+	let stmt = "";
+	if (query.create) {
+		stmt += "CREATE TABLE `" + CONFIG.dbServer.database + "`.`" + query.create + "` (" + query.columns.join() + ") Engine = InnoDB";
+	}
+	if (query.select) {
+		stmt += "SELECT " + query.columns.join() + " FROM `" + CONFIG.dbServer.database + "`.`" + query.select + "` ";
+	}
+	if (query.insert) {
+		stmt += "INSERT INTO `" + CONFIG.dbServer.database + "`.`" + query.insert + "` (" + query.columns.join() + ") VALUES " + query.valueHolders;
+	}
+	if (query.update) {
+		stmt += "UPDATE `" + CONFIG.dbServer.database + "`.`" + query.update + "` SET " + query.sets;
+	}
+	if (query.del) {
+		stmt += "DELETE FROM `" +CONFIG.dbServer.database + "`.`" + query.del + "`";
+	}
+	if (query.where) {
+		stmt += " WHERE " + query.where;
+	}
+	if (query.orderby) {
+		stmt += " ORDER BY " + query.orderby;
+	}
+	//console.log(stmt + "\nValues: " + JSON.stringify(query.values));
+	let [rows, fields] = await con.execute(stmt,query.values).then(con.end());
+	var columns = [];
+	if (fields !== undefined) {
+		fields.forEach((f) => {
+			columns.push(f.name);
+		});
+	}
+	if (getFields) {
+		return [rows,columns];
+	}
+	return rows;
+}
+
+module.exports = {
+	Query : Query
+};

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tank_commander",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -976,6 +976,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1225,6 +1230,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "denque": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -1455,6 +1465,14 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1644,6 +1662,11 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-stream": {
       "version": "2.0.0",
@@ -2311,11 +2334,15 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -2398,6 +2425,60 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "mysql2": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.2.tgz",
+      "integrity": "sha512-JUSA50rt/nSew8aq8xe3pRk5Q4y/M5QdSJn7Ey3ndOlPp2KXuialQ0sS35DNhPT5Z5PnOiIwSSQvKkl1WorqRA==",
+      "requires": {
+        "denque": "^2.0.1",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^4.0.0",
+        "lru-cache": "^6.0.0",
+        "named-placeholders": "^1.1.2",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "sqlstring": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.2.tgz",
+          "integrity": "sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg=="
+        }
+      }
+    },
+    "named-placeholders": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.2.tgz",
+      "integrity": "sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==",
+      "requires": {
+        "lru-cache": "^4.1.3"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
+      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -2606,6 +2687,11 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -2673,8 +2759,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "saxes": {
       "version": "5.0.1",
@@ -2690,6 +2775,11 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
+    },
+    "seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -3092,8 +3182,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/src/package.json
+++ b/src/package.json
@@ -1,22 +1,25 @@
 {
   "name": "tank_commander",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Drunk Tank bot",
   "main": "main.js",
   "scripts": {
-    "testserver": "node main.js testcfg",
-    "testserver:linux": "node main.js test_linux",
+    "testserver": "node --trace-warnings main.js test",
+    "testserver_linux": "node main.js test_linux",
     "druncord": "node main.js druncord",
     "druncord_linux": "node main.js druncord_linux",
-    "test": "jest"
+    "test": "node main.js test_db"
   },
   "license": "ISC",
   "dependencies": {
+    "bluebird": "^3.7.2",
     "discord.js": "^12.5.3",
     "dotenv": "^10.0.0",
-    "moment": "^2.29.1"
+    "moment": "^2.29.1",
+    "mysql2": "^2.3.2"
   },
   "devDependencies": {
     "jest": "^27.0.6"
-  }
+  },
+  "nodeVersion": "12.16.3"
 }

--- a/src/services/bufferService.js
+++ b/src/services/bufferService.js
@@ -1,0 +1,67 @@
+/* DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
+var CONFIG;
+function injectConfig(_cfg) {
+    CONFIG = _cfg;
+}
+*/
+
+//instantiate our db connection manager
+var dbManager = require('../managers/dbConnectionManager.js');
+
+var query = null;
+var buffers = {};
+
+async function queryDB() {
+	rec = await dbManager.Query(query);
+	if (query.select) {
+		buffers = {};
+		rec.forEach((e) => {
+			buffers.time = e;
+		});
+	} else {
+		buffers = {};
+	}
+	query = null;
+}
+
+async function getBuffers() {
+	query = {
+			select: guild + "_buffers",
+			columns: ["*"],
+			where: "?",
+			orderby: "time",
+			values: [1]
+		};
+		
+	await queryDB().then(() => {
+			return buffers;
+	});
+}
+
+async function saveBuffer(channel, msg) {
+	query = {
+		insert: guildID + "_buffers",
+		columns: ["time","channel","msg"],
+		valueHolders: "(?,?,?)",
+		values: [Date.now(),channel,msg]
+	};
+	queryDB();
+}
+
+async function deleteBuffers(b) {
+	var wv = [];
+	b.forEach((e) => {
+		wv.push("?");
+	});
+	query = {
+		del: guildID + "_buffers",
+		where: "id IN (" + wv.join + ")",
+		values: b
+	};
+	queryDB();
+}
+
+//exports.injectConfig = injectConfig;
+exports.getBuffers = getBuffers;
+exports.saveBuffer = saveBuffer;
+exports.deleteBuffers = deleteBuffers;

--- a/src/services/inviteService.js
+++ b/src/services/inviteService.js
@@ -1,0 +1,245 @@
+var dbManager = require('../managers/dbConnectionManager.js');
+var guildService = require('./guildService');
+
+var query = null;
+var qResults = null;
+
+async function queryDB(getColumns) {
+	qResults = await dbManager.Query(query,getColumns);
+	query = null;
+}
+
+async function getInvites(guild) {
+	query = {
+		select: guild + "_invites",
+		columns: ["*"],
+		where: "?",
+		values: [1]
+	};
+	await queryDB();
+	if (!qResults.length) {
+		// no invites... odd.
+		return false;
+	}
+	let invites = {};
+	qResults.forEach((o,i) => {
+		invites[o.code] = {inviter: o.inviter, uses: o.uses, dummies: o.dummies, deleted: o.deleted};
+	});
+	query = {
+		select: guild + "_invite_uses",
+		columns: ["*"],
+		where: "?",
+		values: [1]
+	};
+	await queryDB();
+	if (!qResults.length) {
+		// no invites were used. This can happen when the system is first used and nobody has joined since.
+		// just return the invites object now.
+		return invites;
+	}
+	let uses = {};
+	qResults.forEach((o,i) => {
+		if (uses[o.code] === undefined) {
+			uses[o.code] = {};
+		}
+		if (uses[o.code][o.userId] === undefined) {
+			uses[o.code][o.userId] = [];
+		}
+		uses[o.code][o.userId].push(o.joined);
+	});
+	
+	// Do some lag checking between known uses and listed uses of the two tables,
+	// all while moving the known users into invites.CODE.uses.
+	Object.entries(uses).forEach(([i,o]) =>{
+		var ulist = 0;
+		Object.entries(o).forEach(([u,t]) => {
+			ulist += t.length;
+		});
+		if (invites[i].uses - invites[i].dummies !== ulist) {
+			guildService.writeToChannel('logChannel', 
+			"There was a disparity between the userlist and the uses count in the DB for invite code **" + i + "**." +
+			"\r\nUses count: " + invites[i].uses + " - Users listed: " + (ulist === 1 ? "1 use " : ulist + " uses ") + "and " + (invites[i].dummies === 1 ? "1 dummy" : invites[i].dummies + " dummies")
+			);
+		}
+		invites[i].uses = o;
+	});
+	return invites;
+}
+
+async function updateInvite(guild, invite, remove) {
+  remove = remove === undefined ? false : remove;
+	
+	query = {
+		select: guild + "_invites",
+		columns: ["*"],
+		where: "code = ?",
+		values: [invite.code]
+	};
+	await queryDB();
+	
+	// save results of the select statement before we run the update
+	let dbinvites = JSON.parse(JSON.stringify(qResults));
+	
+	// Make sure we got the invite properly
+	if (!qResults.length) {
+		// we got nothing, which is some kind of serious error or the record may have been manually deleted.
+		return await guildService.writeToChannel('logChannel', 
+			"<@&" + CONFIG.servers[guild].botMasterRole + "> The inviteService of the bot failed to retrieve an invite from the DB when it should have existed. Did someone delete the invite record manually from the DB?"
+		);
+	} else {
+		query = {
+			update: guild + "_invites",
+			sets: null,
+			where: "code = ?",
+			values: null
+		};
+		// did a use happen, or was it deleted?
+		if (remove) {
+			// the uses are the same, which is our way of saying its being deleted.
+			query.sets = "deleted = ?";
+			query.values = [true,invite.code];
+		} else {
+			// just to be safe, invite.uses should be only greater than the db record by 1.
+			// If it isn't, we will update it, but notify the staff in their logchannel.
+			if (invite.uses === (dbinvites[0].uses + 1)) {
+				// it only incremented by one, quickly update it.
+				query.sets = "uses = ?";
+				query.values = [invite.uses,invite.code];
+			} else {
+				await guildService.writeToChannel('logChannel', 
+					"The invite " + invite.code + " saw more than one use between its last update (from " + dbinvites[0].uses + " to " + invite.uses + "). Perhaps the bot got flooded before it had a chance to properly handle newly added users."
+				);
+				query.sets = "uses = ?";
+				query.values = [invite.uses,invite.code];
+			}
+		}
+		
+		await queryDB().then(() =>{
+			if (!dbinvites[0].deleted) {
+			  dbinvites[0].uses = invite.uses;
+			}
+		});
+	}
+	// return back the updated invite object from the DB.
+	return dbinvites[0];
+}
+
+async function createInvite(guild, invite) {
+	query = {
+		insert: guild + "_invites",
+		columns: ["code","inviter","uses","dummies","deleted"],
+		valueHolders: "(?,?,?,?,?)",
+		values: [invite.code, invite.inviter.id, 0, 0, false]
+	};
+	await queryDB();
+	return true;
+}
+
+async function addInviteUse(member, invite) {
+	query = {
+		insert: member.guild.id + "_invite_uses",
+		columns: ["joined","code","userId"],
+		valueHolders: "(?,?,?)",
+		values: [member.joinedTimestamp, invite.code, member.id]
+	}
+	await queryDB();
+	return await updateInvite(member.guild.id, invite);
+}
+
+async function getGuildInvites(guildOBJ) {
+	let invites = [];
+	// First get the vanityURL if it exists
+	if (guildOBJ.vanityURLCode !== null) {
+		if (guildOBJ.vanityURLUses === null) {
+			invites.push({
+				code: guildOBJ.vanityURLCode,
+				inviter: "VANITY_URL",
+				uses: 0,
+				deleted: false
+			});
+		} else {
+			invites.push({
+				code: guildOBJ.vanityURLCode,
+				inviter: "VANITY_URL",
+				uses: guildOBJ.vanityURLUses,
+				deleted: false
+			});
+		}
+	}
+	// get all the invites of the guild and put them into the invites object
+	await guildOBJ.fetchInvites().then((inv) => {
+		inv.forEach((i,k)=>{
+			if (i.code !== guildOBJ.vanityURLCode) {
+				// Currently unknown if Vanity is included. Can't hurt to leave this here.
+				invites.push({
+					code: i.code,
+					inviter: i.inviter.id,
+					uses: i.uses,
+					deleted: false
+				});
+			}
+		});
+	});
+	return invites;
+}
+
+async function storeInvites(guildOBJ) {
+	let dbInvites = await getInvites(guildOBJ.id);
+	let ti = await getGuildInvites(guildOBJ);
+	let invites = [];
+	if (dbInvites) {
+		// only perform loop if we had any invites in the db
+		ti.forEach((i,k) => {
+			if (dbInvites[i.code] === undefined) {
+				// invite not in db
+				invites.push(ti[k]);
+			}
+		});
+	} else {
+		invites = ti;
+	}
+	
+	if (invites.length) {
+		// only do something if we had an invite to save
+		query = {
+			insert: guildOBJ.id + "_invites",
+			columns: ["code","inviter","uses","dummies","deleted"],
+			valueHolders: "",
+			values: []
+		};
+		let query_uses = [];
+		// set up the query for multiple inserts, and prep the dummy uses for each invite
+		invites.forEach((i,k)=>{
+			query.valueHolders += " (?,?,?,?,?)";
+			query.valueHolders += (invites.length - 1 > k ? ", " : "");
+			// code initially discovered has dummies set to its current uses
+			query.values.push(i.code,i.inviter,i.uses,i.uses,i.deleted);
+			query_uses.push(i.code,i.uses);
+		});
+		
+		// Insert the invites
+		await queryDB();
+		
+		// grab the DB again to verify the now exist
+		dbInvites = await getInvites(guildOBJ.id);
+		let invs = {saved:0, lost:0, err: false};
+		invites.forEach((i,k) => {
+			if (dbInvites[i.code] !== undefined) {
+				invs.saved++;
+			} else {
+				invs.lost++;
+				invs.err = true;
+			}
+		});
+		return invs;
+	} else {
+		return {saved: 0, err: false};
+	}
+}
+
+exports.getInvites = getInvites;
+exports.updateInvite = updateInvite;
+exports.createInvite = createInvite;
+exports.addInviteUse = addInviteUse;
+exports.storeInvites = storeInvites;
+exports.getGuildInvites = getGuildInvites;

--- a/src/services/persistenceService.js
+++ b/src/services/persistenceService.js
@@ -1,17 +1,31 @@
-var fs = require('fs');
-var CONFIG;
+const HELPERS = require('../helpers/helpers');
+//instantiate our db connection manager
+var dbManager = require('../managers/dbConnectionManager.js');
 
-function injectConfig(myConfig) {
-    CONFIG = myConfig;
+var query = null;
+var qResults = null;
+var tankees = {};
+var sips = {};
+
+/* DEPRECATED AND REMOVED; CONFIG lives in global namespace of main.js
+var CONFIG;
+function injectConfig(_cfg) {
+    CONFIG = _cfg;
+}
+*/
+
+async function queryDB(getColumns) {
+	qResults = await dbManager.Query(query,getColumns);
+	query = null;
 }
 
 /*
-Save an individual user tanking event
+Save an individual user tanking event as a new record
 */
-function saveTanking(userToTankId, authorNickname, reason, duration, uom, oldRoles) {
+async function saveTanking(guildID, userTanked, tankedBy, tankReason, duration, uom, oldRoles) {
     let ts = Date.now();
     let untank_time = 0;
-
+    
     switch (uom) {
         case "days": 
             untank_time = ts + (duration*24*60*60*1000)
@@ -25,52 +39,50 @@ function saveTanking(userToTankId, authorNickname, reason, duration, uom, oldRol
     }
 
     tankee_obj = {
-        user_tanked: userToTankId,
-        tanked_by: authorNickname,
-        reason: reason, 
         time_tanked: ts,
+				user_tanked: userTanked,
+        tanked_by: tankedBy,
+        tank_reason: reason,
         time_to_untank: untank_time,
-        role_to_remove: CONFIG.drunktankRole,
-        roles_to_give_back: oldRoles,
-        archive: false,
-        historical_tank: false
+        roles_to_give_back: oldRoles.join(","),
+        time_untanked: null,
+				untanked_by: null,
+				untanked_reason: null
     }
-
-    if (!fs.existsSync(CONFIG.json_path)) {
-        fs.writeFileSync(CONFIG.json_path, JSON.stringify([tankee_obj]));
-    }
-    else {
-        var data = fs.readFileSync(CONFIG.json_path);
-        var json = JSON.parse(data);
-        json.push(tankee_obj);
-        fs.writeFileSync(CONFIG.json_path, JSON.stringify(json));
-    }
+		
+		query = {
+			insert: guildID + "_tankees",
+			columns: Object.keys(tankee_obj),
+			valueHolders: [],
+			values: []
+		};
+		
+		Object.keys(tankee_obj).forEach((k) => {
+			query.valueHolders.push("?");
+			query.values.push(tankee_obj[k]);
+		});
+		query.valueHolders = "(" + query.valueHolders.join() + ")";
+    queryDB();
 }
 
 /*
-Remove all active tanking records for an individual user
+Update a tanked user record to be untanked
 */
-function saveUntanking(userIdToUntank) {
-    data = fs.readFileSync(CONFIG.json_path);
-    var json = JSON.parse(data)
-    var user;
-    for (n=0;n<json.length; n++) {
-        if (json[n].archive) {
-            continue;   
-        }
-        if (json[n].user_tanked == userIdToUntank) {
-            json[n].archive = true;
-            user = json[n];
-        }
-    }
-
-    fs.writeFileSync(CONFIG.json_path, JSON.stringify(json))
-
-    return user;
+async function saveUntanking(guildID, userIdToUntank, untanker, untankReason) {
+		let ts = Date.now();
+		
+		query = {
+			update: guildID + "_tankees",
+			sets:  "time_untanked = ?, untanked_by = ?, untanked_reason = ?",
+			where: "((time_untanked IS NULL) AND (user_tanked = ?))",
+			values: [ts,untanker,untankReason,userIdToUntank]
+		};
+		queryDB();
 }
 
 /*
 Update a tanked user to say they've left (thus removing them from the checktank)
+ DEPRECATED; users stay in tank but are not mentioned in checktank command if they are not in the server
 */
 function saveUserLeaving(userIdThatLeft) {
     data = fs.readFileSync(CONFIG.json_path);
@@ -95,6 +107,7 @@ function saveUserLeaving(userIdThatLeft) {
 
 /*
 Update a newly joined user to say they have rejoined (thus including them in checktank again)
+ DEPRECATED; users stay in tank but are not mentioned in checktank command if they are not in the server
 */
 function saveUserJoining(userIdThatJoined) {
     data = fs.readFileSync(CONFIG.json_path);
@@ -118,19 +131,51 @@ function saveUserJoining(userIdThatJoined) {
 }
 
 /*
-returns a json array of all currently tanked users
+returns a json array of all currently tanked users from guild
+function will not filter results unless second arg evaluates to true
+function accepts third arg as userID to get only one user -- used instead of getUser()
 */
-function getTankedUsers() {
-    if (!fs.existsSync(CONFIG.json_path)) {
-        return [];
-    }
-    var data = fs.readFileSync(CONFIG.json_path);
-    var json = JSON.parse(data)
-    return json.filter(obj => obj.archive == false);
+async function getTankedUsers(guild, filter, user) {
+    if (arguments.length === 1) {
+			filter = false;
+		}
+		if (arguments.length === 2) {
+		  user = false;
+		}
+		
+		query = {
+			select: guild + "_tankees",
+			columns: ["*"],
+			where: "?",
+			values: [1]
+		};
+		
+		if (filter) {
+			if (user) {
+			  query.where = "((user_tanked = ?) AND (time_untanked IS NULL))";
+				query.values = [user];
+			} else {
+				query.where = "time_untanked IS NULL";
+				query.values = [];
+			}
+		}
+		await queryDB()
+		.then(() => {
+			tankees = {};
+		  qResults.forEach((e) => {
+				tankees[e.time_tanked] = e;
+			});
+		})
+		
+		.then(() => {
+			tankees = HELPERS.convertDataFromDB(tankees,"tank");
+		});
+		return tankees;
 }
 
 /*
 returns a json array of all full tank history
+DEPRECATED; filtration of tanked vs all is now handled by getTankedUsers()
 */
 function getTankHistory() {
     if (!fs.existsSync(CONFIG.json_path)) {
@@ -143,8 +188,9 @@ function getTankHistory() {
 
 /*
 returns a json representation of a tanked user if there is one
+DEPRECATED; uses getTankedUsers(guildID, true, UserID)
 */
-function getUser(userIdToGet) {
+function getUser(guild, userIdToGet) {
     data = fs.readFileSync(CONFIG.json_path);
     var json = JSON.parse(data)
     user = json.find(obj => obj.archive == false && obj.user_tanked == userIdToGet);
@@ -154,6 +200,8 @@ function getUser(userIdToGet) {
 /*
 returns a json representation of a tanked user if there is one
 checks historical records too to see if theyve left whilst tanked
+DEPRECATED; getTankedUsers() now returns this data.
+calling guildService.guild.member(id) verifies if the user is still in the server or not, and check if the user has not been untanked by untanked_time === null.
 */
 function getUserHistorical(userIdToGet) {
     data = fs.readFileSync(CONFIG.json_path);
@@ -170,85 +218,83 @@ function getUserHistorical(userIdToGet) {
 /*
 Add a sip to the sip json 
 */
-function addSip(sipStr, userID, nickname) {
-    var obj = getSipCountForUser(sipStr, userID);
-    if (obj == undefined) {
-        obj = {
-            userID: userID,
-            count: 1,
-            nickname: nickname,
-            sipStr: sipStr
-        }
-    } else {
-        obj = {
-            userID: userID,
-            count: obj.count + 1,
-            nickname: nickname,
-            sipStr: sipStr
-        }
-        
-    }
-
-    if (!fs.existsSync(CONFIG.countedJsonPath)) {
-        fs.writeFileSync(CONFIG.countedJsonPath, JSON.stringify([obj]));
-    } else {
-        var data = fs.readFileSync(CONFIG.countedJsonPath);
-        var json = JSON.parse(data);
-
-        var toAdd=true;
-        for (n=0;n<json.length; n++) {
-            x = json[n];
-            if (x.userID == obj.userID && x.sipStr == obj.sipStr) {
-                x.count = obj.count;
-                toAdd = false;
-                break;
-            }
-        }
-
-        if (toAdd) {
-            json.push(obj);
-        }
-        
-        fs.writeFileSync(CONFIG.countedJsonPath, JSON.stringify(json));
-    }
-    return obj;
+async function addSip(guild, sipStr, userID, t) {
+    var u = await getSipCountForUser(guild,userID)		
+		// the sipstring was already validated, so it is safe to concat it into the columns.
+		// Check for minimum time between sips
+		if ((u !== undefined) && (t - u.lastSip < 7000)) { // 7 seconds minimum sounds reasonable between sips
+			u.slow = true;
+			console.log(u);
+			return u;
+		} else {
+			if (u !== undefined) {
+				u[sipStr]++;
+				query = {
+					update: guild + "_sips",
+					sets: "lastSip = ?," + sipStr + " = ?",
+					where: "(userId = ?)",
+					values: [t,(u[sipStr]),userID]
+				};
+			} else {
+				u = {userId: userID};
+				u[sipStr] = 1;
+				query = {
+					insert: guild + "_sips",
+					columns: ["userId","lastSip",sipStr],
+					valueHolders: "(?,?,?)",
+					values: [userID,t,1]
+				};
+			}
+			await queryDB();
+			return u;
+		}
 }
 
 /*
 Return a list of all historical sips
 */
-function getAllSips() {
-    var data = fs.readFileSync(CONFIG.countedJsonPath);
-    var json = JSON.parse(data)
-    return json;
+async function getAllSips(guild) {
+		let rData = {structure: [], data: []};
+		query = {
+			select: guild + "_sips",
+			columns: ["*"],
+			where: "?",
+			values: [1]
+		};
+		await queryDB(true)
+		
+		.then(() => {
+			rData.structure = qResults[1];
+			qResults[0].forEach((e) => {
+				rData.data.push(e);
+			});
+		});
+		return rData;
 }
 
 /*
 Return the sip count for an individual user
 */
-function getSipCountForUser(sipStr, userID) {
-    if (!fs.existsSync(CONFIG.countedJsonPath)) {
-        return {
-            userID: userID,
-            count: "0",
-            sipStr: sipStr
-        }
-    }
-    data = fs.readFileSync(CONFIG.countedJsonPath);
-    var json = JSON.parse(data)
-    user = json.find(obj => obj.userID == userID && obj.sipStr == sipStr);
-    return user;
+async function getSipCountForUser(guild, userID) {
+		query = {
+			select: guild + "_sips",
+			columns: ["*"],
+			where: "userId = ?",
+			values: [userID]
+		}
+		await queryDB();
+		return qResults[0];
 }
 
 exports.addSip = addSip;
 exports.getAllSips = getAllSips;
 exports.getSipCountForUser = getSipCountForUser;
-exports.getUser = getUser;
+//exports.getUser = getUser; //DEPRECATED
 exports.saveTanking = saveTanking;
 exports.getTankedUsers = getTankedUsers;
 exports.saveUntanking = saveUntanking;
-exports.injectConfig = injectConfig;
-exports.getTankHistory = getTankHistory;
-exports.getUserHistorical = getUserHistorical;
-exports.saveUserJoining = saveUserJoining;
-exports.saveUserLeaving = saveUserLeaving;
+//exports.injectConfig = injectConfig; //DEPRECATED AND REMOVED
+//exports.getTankHistory = getTankHistory; //DEPRECATED
+//exports.getUserHistorical = getUserHistorical; DEPRECATED
+//exports.saveUserJoining = saveUserJoining; //DEPRECATED
+//exports.saveUserLeaving = saveUserLeaving; //DEPRECATED


### PR DESCRIPTION
Many functions have been rewritten to accommodate the new methods to work with a database, many functions and variables have been removed due to immediate deprecation, and many new functions, services, event handlers, and command handlers have been added. The code still needs to be documented and properly commented, as well as undergo a full naming rework for variables utilized within the Discord.js API to eliminate confusion on expected data being passed and worked with. Discord.js version is still using API v12 instead of v13 (which contains breaking changes).

Database uses serverID_TableName convention per server that is configured, and all configurations are held in the table 'config'. 'retorts' contains a list of all the snarky responses the bot will use when bothered in DM.
Structures for tankees, sips, invites, invite_uses, and buffers can be found in configCommand.
Structure for retorts is a keyless single column labelled 'line'.
Structure for 'config' is as follows:

  'serverID' VARCHAR(20) NOT NULL PRIMARY KEY,
  'commandPrefix' VARCHAR(1) NOT NULL DEFAULT('.')
  'botMasterRole' VARCHAR(20) NULL DEFAULT(NULL)
  'botUserRole' VARCHAR(20) NULL DEFAULT(NULL)
  'drunktankRole' VARCHAR(20) NULL DEFAULT(NULL)
  'tankChannel' VARCHAR(20) NULL DEFAULT(NULL)
  'logChannel' VARCHAR(20) NULL DEFAULT(NULL)
  'invitesChannel' VARCHAR(20) NULL DEFAULT(NULL)
  'namesChannel' VARCHAR(20) NULL DEFAULT(NULL)
  'modlogChannel' VARCHAR(20) NULL DEFAULT(NULL)
  'bypassGMU' VARCHAR(419) NOT NULL
  'rolesToIgnore' VARCHAR(419) NULL DEFAULT(NULL)
  'rolesICannotTank' VARCHAR(419) NULL DEFAULT(NULL)
  'tankUOM' VARCHAR(7) NOT NULL DEFAULT("hours")
  'tankDuration' SMALLINT(5) UNSIGNED NOT NULL DEFAULT(12)
  'writeMessageToDrunkTank ' TINYINT(1) UNSIGNED NOT NULL DEFAULT(0)
  'warnAuthorizedUsage' TINYINT(1) UNSIGNED NOT NULL DEFAULT(0)
  'startServer' TINYINT(1) UNSIGNED NOT NULL DEFAULT(0)

All Discord Snowflake numbers are strings due to the inability to utilize BigInt() in our bot. All snowflakes when passed as numbers, integers, or any large number datatype, always truncate digits to the right when the value exceeds javascript's MAX_SAFE_INTEGER, which is 2^53-1 (9007199254740991). Because Snowflakes are up to 20 digits and make up a value that can be up to the max unsigned value of a 64-bit integer, we cannot rely on anything other than strings, and we are never able to perform any mathematical operations nor use any mathematical comparisons with snowflakes within our bot.

commandPrefix was decided by Sindrah to currently be limited to a single character, so as to not have issues with overlapping or word usage.

large VarChar sizes were chosen for comma-separated lists of snowflake IDs, and huge sizes (blob types are not required as the max message size of a Level 3 boosted server is 4000 UTF8 characters) for messages buffered.

TinyInt(1) is for boolean values.

ALL occurrences of injectConfig() are now Deprecated and Removed. injection functions, and some other functions/variables, are currently commented out (or may still exist but are not exported any longer) and are to be blown out on next code beautification.

main.js
  set default to use druncord_linux
  moved service instantiation to occur after database connection occurs and all server configuration has been obtained
  implements database callable
  moved config into the global namespace so it can be seen from all includes without injecting it. This allows changes from one service/command/event to be reflected in other later-called services that would otherwise need to be re-injected.
  config is now an Object sorted by server ID with individual and independent server configurations.
  bot now has retorts (stored in database) that it randomly responds with when DM'd out of context (to be reworked where no retort is issued for manual tanking responses in DM by botUsers, or Deprecated altogether if problematic)
  main script now listens to the following new events:
    inviteCreate,
    inviteDelete,
    userUpdate -> fed to memberUpdateEvent for handling. currently only used for tracking username changes, and uses existing code to respond to it the same way it would for a nickname change from a GuildMember object.
  all caught events that ultimately require some kind of configuration in order to move forward will first check if the server configuration not only exists but that every required part of the configuration has been configured, otherwise it responds that the server has not been configured yet, and instructs the user to use the configuration commands.

package.json
  new version "1.0.0" for breaking and major changes, currently in production
  testserver now stacktraces warnings and errors
  testserver_linux contained a colon character that prevented it from being properly read as an index
  new packages were added: mysql2, bluebird (promises)
  nodeVersion added by npm

package-lock.json
  reflects dependencies and changes found in package.json

config/
  druncord_linux.js
  hard-coded configurations for the server have been removed, except for the bot token access code and bot name
  included database connection details pulled from .env (keeps the credentials secret using .gitignore when cloned)

managers/
  dbConnectionManager.js
    new file. handles all database connections, single transaction mode within an async promise, returns results of query.
    utilizes prepared statements with parameterized SQL to prevent SQL injection without having to sanitize any data.
    limited DDL/DML query functions permitted in order to prevent injection by 2nd order (using unions or stored functions).
    all query components are standardized to be handled without allowing any code to manipulate the query string. all query data is built based on the existence of the passed data, and the query string is strictly assembled based on the named properties of the object passed to the querybuilder.

events/
  memberJoinEvent.js
    logs joining users with their account details and the Invite they used to join (and references the invite creator's details)
    tank persistence rewritten due to database usage instead of JSON flatfile.
    if tanked user comes back after time is served, untank procedure is automatically called to untank them.

  memberLeaveEvent.js
    rewritten checktank to still show user in tank after they leave (future update to label the user as not in server so auto-untank happens if/when they return without botUser involvement)
    logs user leaving in special log with user information (ID, user.tag, current mention handle, account age, time in server, and invite used as well as inviter).
    notates if the user was kicked, banned, or left on their own.
    banned users that were tanked have their tank record closed with reason "Banned".

  memberUpdateEvent.js
    now tracks username changes, nickname changes, and tracks all roles given or taken that aren't involving the drunktankRole
    reworked logic for checking if the user being manipulated with drunktankRole was in the tank records before working on a tank record, otherwise outputs message that the user was not in the tank.
    removed the exception catch() that only sent a warning to the console if the audit log entry couldn't be found. Eventually will reinstate when all unhandled promise rejections are explicitly handled.

  inviteEvent.js
    new file. simply determines the data of an invite caught by the event trigger, and determines whether it was newly added or deleted, then adds/updates the record in the DB accordingly.

services/
  drunktankService.js
    refactored the way users are handled in each function and procedure within to accommodate for the DB.
    handles tank command upon a tanked user to just close out their current tank record with reason "Already tanked - retanking" then open a new tanking record for the tanked user.

  guildService.js
    writeToChannel() function refactored to consider a message that may be buffered or just lost entirely if the channel is not valid. No longer receives a channel ID, instead receives a channel namespace found in a server's config that is used to get the channel ID by the name as an index.
    buffer message true by default, pass explicit false as third arg to override message buffering.
    getMemberFromCache() now returns the entire guildMember object that is fetched
    setRolesForMember() was fixed. An empty string as the only role in .roles occurs when they have no roles (fixed by setting it to an empty array), and properly returns the newly refreshed GuildMember Object or null if the guildMember is not found.
    reworded console log output from getExecutorForRoleChangeFromAuditLog()
    notated that API v13 uses an new method to disconnect a user from voice channel (preemptive).

  persistenceService.js
    massive refactor of saveTanking() and saveUntanking() to make use of a DB, and redesigned the tankee object to not record usernames or nicknames (unnecessary, this data can be obtained via their ID and guildService appropriately, and username/nickname are now logged instead for posterity when the commands are issued).
    saveUserLeaving() and saveUserJoining() functions are now Deprecated and no longer used, as the bot now handles role persistence for the drunktankRole on its own using the database records.
    getTankedUsers() function is used for all instances of obtaining tankee records, and can have the query filter the results to only currently tanked users or limit the records to a specific user that is currently tanked.
    getTankHistory Deprecated. uses getTankedUsers() without filtering
    getUser() Deprecated. uses getTankedUsers() by filtering and passing a specific userID.
    getUserHistorical() Deprecated. combine getTankedUsers() with filter by userID and guildService.guild.member(id) to determine if the tanked user is still here or not.
    addSip() has been reworked for Database usage. Sips, along with any other allowed string (considered a "sipstring"), are stored in a table by UserID, lastSip, and each further column is named the sipString which holds the integer sipcount for that sipstring.
    addSip() now throttles users from being able to spam a sip command (currently hardcoded to 7000ms compared from their loast recorded sip). Currently the column for lastSip is compared for all sipStrings, so the throttle is applied to the entire sipCommand usage regardless of what string is passed.

  tankStatsService.js
    reworked to make use of Database fetched results, and includes new stats for untankings (Staff that care).
    added function filterTankStats(guild, user) to allow for searching the tank records based on a specific user.
    minor capitalization changes in output message, and altered typed occurrence of "Mod" to "Staff" (to reduce the notion that Barbacks are Mods within Druncord).
    changed the output of staff nicknames to be their mention handles instead. NOTE: if staff get annoyed being tagged by tankstats to the point of needing a change, implement a blank message to be sent first, get that message ID, then edit that message with the built content being sent out so pings don't occur but the tags reflect username/nickname changes.

  inviteService.js
    new file. handles obtaining all current guild invites and the stored invite data from the DB, performs some checks on usage counts, considers the fact that invites may predate the bot's recording of invites, and accounts for that using a dummy counter (number of uses on an invite prior to tracking by the bot). Handles determining which invite was most recently incremented by one compared to the previously known counts.
    if an incremented invite cannot be ascertained, and the used invite of a joiner is unknown, all invites in the DB will have their dummy counts fixed to reflect proper counts and uses.
    There are 2 tables containing invite data: one for the invite itself (contains invite code, inviter user ID, tracked uses, dummy count, and whether the invite has been deleted), the other table has a list of invite uses (arranged by joindatetime, code, and userID).

  bufferService.js
    new file. averts errors of invalid channel, and prevents loss of the output log messages, by saving message content for a log channel when that channel doesn't actually exist (deleted channel). When the server config has a valid channel for a particular log group, all saved messages are sent to the valid log channel, and the records are purged from the buffers table in the DB on success for each.

  syncTankService.js
    Deprecated, and unchanged. may be repurposed for auto-untanking after time served.

commands/
  checkTankCommand.js
    refactored to handle the data organized from the database records. data gets organized a little different now to make searching and iterating through it all a bit faster and easier. for data structure, see persistenceService.getTankedUsers().
    due to explicit handling of what we use for userID when a tanking botUser doesn't exist, which should be impossible anyway, the conditional check of obj.tanked_by == "Unknown" will never be true, so the output of the bot "learning" about an unknown tankee won't ever happen. consider removing it or move it to a promise rejection handler.

  commandParser.js
    updated countedStrings to reference only the columns in the sips table (except userID and lastSip). This effectively configures a server's sipStrings allowed by simply tracking them.
    There is currently no handler or command to add, update, or remove a sipString - needs to be handled in the DB manually by altering the table structure itself. Might eventually implement botMasterRole/Admin to be allowed to use such a command.
    considering Deprecating the catch of mistakes (double prefix, prefix + space, prefix + p) as we simply don't handle anything that isn't a case of command.
    reworked the test of whether a user has the right to use the bot based on botUserRole, botMasterRole, or if they have the Administrator privilege.
    added case for "config" command.
    case "syncTank" Deprecated and removed (commented). Considering repurpose of command to be an automated process to untank users that have served their time (triggered on every handled event).
    no longer need to inject config to anything, now deprecated and removed (commented out).
    wrote an explicit check whereby an unconfigured server doesn't respond to commands at all, unless the command is specifically ".configure" (default prefix with "configure", not "config") and it is used by a user that has Administrator. This configure command only works whilst the server has not fully been configured, and assists in setting up the default configs and walks the admin through the process of getting the server ready.

  helpCommand.js
    used another variable to short reference the server configured command prefix for cleaner and shorter code.
    added help entry for "config" command.
    "synctank" command Deprecated and removed (commented out).

  sipCommand.js
    implemented sipCommand to use throttling (hard-coded wait time set in persistenceService.addSip())
    hard-coded responses when sip is throttled.
    refactored existing responses for sips to reference the string that triggered the command (in case other words are allowed) NOTE: due to how the English language is, it may be beneficial to include a table of the sip strings with their permutations of past-tense/plural/present-tense-ing/etc so the proper references don't have to be hard-coded with a ton of regex cases that try to figure out how to properly spell the word (such as trying to figure out how not to mispell sipping and farting, etc.).
    added an ego-boosting message that gets triggered when Sindrah triggers the sipCommand, but the command only responds as though the string is "sip". NOTE: Sindrah has never had sip counts, and doesn't care to, but decided to make this message just in case anyone ever asked him what his sip count is, and decided it would be better and funnier instead of abusing DB access and setting his own sipcount to some godawful number. Stevie_pricks had a sipcount and still uses the command, so no ego-boosting message was implemented (yet).
    sip command is ignored if sent in the tankChannel of the server. By logic flow, Sindrah's personal ego boosting message response can be performed in the tank channel (can be moved under the tankChannel check if it bugs anyone).

  sipStatsCommand.js
    refactored for structure and data coming from the database.
    output shows Display name in server with user tag in parentheses and their count (recently hotfixed from using @mention handlers in order to close a flaw whereby a user could spam tag the top 5).

  tankCommand.js
    moved the variables that fetch a member object for tankee, author, and the drunktankRole, to occur after we validate the arguments are correct in count. nothing bad really happens the original way, but there is no reason to continue if the command is invalid.

  tankStatsCommand.js
    command handle now accepts a second argument to be a user mention handle or a user ID (checked in that order). If a valid user is passed, will pass the user ID obtained from the command to filter the tankstats records by that user as the tanker or the tankee, otherwise just performs normal tankstats with the new untank data.

  untankCommand.js
    altered how we check for valid token length (now checks if first array element of tokens is an empty string -- failing to provide anything after the command results in a single element array that contains an empty string, which will pass as true in the previous method).
    wrote a check for when the user mention cannot be utilized due to the user leaving before the untank command gets run (the user mention fails because the handle now contains a bang character after the @ sign, and message.mentions.users only contains users that are still in the guild).
    If the check determines the user is gone, we also need to bypass the function validateMentions() because there won't be a valid mention in the command. Instead, their ID number is sifted by stripping the opening and closing bracket characters for the mention handle in the message (that contains a "!").
    Modify untank message to not show as much detail as normal if the user is already gone. Single line saying "author.mention untanked tankee.user.tag (ID), but they aren't in the server anymore.", then close out their tank record with reason "Time served - Cleanup user not in server".
    removed output mention of running synctank command (command Deprecated).

  configCommand.js
    new file. handles all aspects of .configure (unconfigured server and run by Admin) and .config (configured and running server and executed by botMasterRole or Admin).
    allows altering of server configuration without having to stop/restart the bot.
    using ".config help" or ".configure help" produces the current server configuration and its available command options
    Each command option has its own help output for usage and guidance.
    configuring a server generates unique tables for recording all data by this bot.
    allows explicit reloading of server configuration for the server the command is executed on.

  syncTankCommand.js
    Deprecated, and unchanged. may be repurposed for auto-untanking after time served.

helpers/
  helpers.js
    added fisherYates() shuffle algorithm
    updated validateMentions() to properly respond generically instead of explicitly assuming the command used was "tank", and properly includes whether a reason is required or optional (based on command used).
    changed the the term "@'d" to "@mentioned"
    doesUserHaveRole() Deprecated and removed (no longer in file). This function is highly unnecessary due to the passing of the very object that can be checked inline using .includes() with less characters than it takes to call this function.
    getAtString Deprecated and removed (commented out). Another function that takes more characters to call than just doing it inline and provides no logical checking.
    updated algorithm for removeRoleFRomArray() to use the .forEach() method instead of a plain for loop, and we return the roleArray after whatever is done, if anything. Empty array is returned if we get undefined at the start, which happens when there are no roles.
    added convertDataFromDB() function to normalize the data types coming from the database and implicitly set default values if anything is invalid.
    NOTE: Need to double check for any more functions that are not called or used anymore that were not specifically mentioned as being Deprecated, and identify functions that are written with a narrow usage for a single service/command/event and move them to that file; no reason to have a single-purpose function get bumped around.

  messages.js
    altered confirm_message to confirm_tank_message
    all functions referencing a user's name in any way now have the user/guildmember object itself, and make use of a user mention or their in server Display Name and include tag and ID.
    confirmation messages don't tag the botUser, they use guildMember.displayName.
    Tanked/Untanked messages in the log channel mention both the tanker and tankee, and now include user.tag and user.id of the botUser for posterity (staff changed their names frequently, and on odd occasions, lots of staff set their name to the same name for a fun time, to which this would have been utter chaos if everyone had the same name at the time someone got tanked/untanked).
    log_blue_untank_msg now implements untank reason (default "Assumed Time Served" set by function calling this function).
    tank_msg now @mentions the tanked user
    added user_leave_msg, user_join_msg, user_name_change, and log_role_change to handle special logging of user information when they leave, join, change their name, or a role is granted/removed outside of tanking/untanking.

  logger.js
    no changes.

  KNOWN ISSUES
  .configure command on an unconfigured server did not work to initially configure a server (had to manually create the tables and manually insert the server configuration due to a hasty bot swapover). The entire command did work in testing when hosted on a PC using GIT-CLI, but failed miserably when hosted on the production linux server. Requires further testing with another discord server and debugging.

  many events are being fired twice (and subsequently caught twice), or are being retriggered after getting handled (such as Tank/Untank messages being sent twice, one for the botUser as the tanker, the second as TankCommander being the Tanker, or users joining/leaving are generating duplicate join/leave logs). This is benign and does not affect the recorded data of the occurrences, but it can be annoying to have double logs for each action that may contain mention handles, plus it may just serve to clog up the log channels. Need to look into why a second triggering occurs and come up with a way to either prevent it from double-firing or identify duplicate triggered events and just drop them with an empty return.

  tankStats was designed to allow for searching tank records by a specific user and would show stats for that user (such as how many times they were tanked, what staff members tanked them, etc) and if that user was staff it would show all users they tanked and provide stats based on that. Probably something silly and simple, but specific tankstats are not working; it's always plain tankstats even when a user is passed as an arg.

  checktank will display users that are still serving time but have left or been banned (except when a ban is issued with a tanked user still in server, their record gets closed as part of the catch). Users that were kicked or left are intentionally displayed at this time to show who is still serving time, in case they return, but banned users that already left don't get picked up (not a bug, it's due to how we handle and catch bans by comparing the banlist after a user leaves within userLeaveEvent rather than listening for a GuildBanAdd event - which was not working during testing so that method was abandoned). The best idea to combat this shortcoming so botUsers don't have to manually .untank banned users stuck in the tank is to implement an auto-untank procedure on all time-served records, which also makes botUser's work less involved by not having to untank people that serve their time.

  invites are not getting properly handled when it involves the vanity URL. This could not be tested due to lacking boost level 3 on a test server - this will be difficult to test without having to restart the bot on every change/attempt. If we are to truly test this, either we need to boost a test server, find a way to have our services/commands reloaded on each event trigger so the bot doesn't have to be restarted after a testing change, or we will need to test it using another bot in the boosted server.

  bufferService has not been tested in the production server environment, just the testing environment (worked well, but considering some things worked in testing and failed completely in production, this needs attention).

  ClientService has not been implemented yet (not certain what it was supposed to be for, but my best guess is moving all the client.on() listeners from main.js to its own service).

  There are tons of occurrences that result in Promise Rejections, which are being deprecated and will result in terminating our node.js process (fully blow up the bot and require a manual restart). Top Priority is to write explicit promise rejection handlers and exception handlers for EVERYTHING before this change occurs.

  If there is anything I forgot or failed to discover thus far, I'll open a ticket on it.